### PR TITLE
rename to sync blog post

### DIFF
--- a/.github/workflows/sync-blog-post.yml
+++ b/.github/workflows/sync-blog-post.yml
@@ -1,7 +1,7 @@
-name: Sync Post
+name: Sync Blog Post
 on:
   repository_dispatch:
-    types: [sync-post]
+    types: [sync-blog-post]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- rename the file to sync-blog-post and repository dispatch types as well