### PR TITLE
Publish Post: [Engineering Log] The Brittle JSON: Grafana Provisioning Failure

### DIFF
--- a/blog/engineering-log-the-brittle-json-grafana-provisioning-failure.md
+++ b/blog/engineering-log-the-brittle-json-grafana-provisioning-failure.md
@@ -3,7 +3,6 @@ title: "[Engineering Log] The Brittle JSON: Grafana Provisioning Failure"
 description: "Fixing Grafana dashboard provisioning by moving from brittle embedded JSON in values.yaml to standalone files, resolving 'invalid character' bugs once and for all."
 date: 2026-04-07
 tags: ["retrospective", "platform"]
-draft: true
 ---
 
 ## Context


### PR DESCRIPTION
This PR publishes a post titled **[Engineering Log] The Brittle JSON: Grafana Provisioning Failure** to the blog. 🎉