### PR TITLE
feat(portfolio): optimize projects layout and repair mobile padding

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -48,7 +48,7 @@
 </head>
 
 <body class="bg-slate-950 text-slate-200 font-sans antialiased min-h-screen flex flex-col items-center">
-    <div class="w-full max-w-3xl flex flex-col min-h-screen gap-12 px- py-10">
+    <div class="w-full max-w-3xl flex flex-col min-h-screen gap-12 px-6 md:px-8 py-10">
         {{ template "header" . }}
 
         <main class="w-full grow">

--- a/internal/templates/contents/profile.yaml
+++ b/internal/templates/contents/profile.yaml
@@ -17,13 +17,13 @@ site:
       - My time at Shopify reinforced a 'measure twice, cut once' mindset. Working on systems supporting millions of users shaped how I approach engineering, focusing on preventing regressions, designing for correctness early, and ensuring systems remain resilient under high concurrency and real-world production load.
       - This site is where architectural logic meets the reality of continuous learning. I document the 'why' behind decisions, the trade-offs of every stack, and the reasoning behind system design choices, driven by curiosity and a desire to understand how things work beneath the surface.
   now:
-    lastUpdated: May 2026
+    lastUpdated: June 2026
     categories:
       - title: Work & Projects
         items:
-          - Completed Software Development at SAIT (graduating June 2026).
+          - SAIT 2026 - Software Development Program.
           - Actively seeking a New Grad Software Developer role.
-          - Refining and maintaining Uptime Monitor, Cover Craft, and Observability Hub projects.
+          - Refining and maintaining Uptime Monitor, Cover Craft, Dev Toolchain and Observability Hub projects.
 
       - title: Books & Learning
         items:
@@ -34,6 +34,6 @@ site:
 
       - title: Personal
         items:
-          - Based in Calgary, Alberta.
+          - Based in Greater Vancouver Metropolitan Area.
           - Staying consistent with daily exercise.
           - Exploring hardware and edge systems for future projects.

--- a/internal/templates/contents/projects.yaml
+++ b/internal/templates/contents/projects.yaml
@@ -29,6 +29,14 @@ projects:
       - Azure
       - GitHub Actions
       - MongoDB Atlas
+  - title: Dev Toolchain
+    emoji: 🛠️
+    shortDescription: A portable library of reusable AI agent skills and helper scripts, structured under the SKILL.md open standard to orchestrate consistent developer workflows across compatible LLM clients. 
+    link: dev-toolchain
+    techs:
+      - Automation
+      - Bash
+      - Agentic Enablement
   - title: Echo (MCP server)
     emoji: 🗣️
     shortDescription: Engineered an MCP server to solve the LLM statelessness gap. Tracks Unit Economics and carbon impact via DuckDB while ensuring sub-10ms query via FTS5, WAL and knowledge refinement.
@@ -38,18 +46,9 @@ projects:
       - SQLite
       - DuckDB
       - MCP Server
-  - title: CarbonOps
-    emoji: 🌿
-    shortDescription: Experimental Rust CLI for Kubernetes infrastructure observability, collecting workload metrics, node usage, and Prometheus/Kepler energy signals across local and cloud Kubernetes clusters.
-    link: carbonops
-    techs:
-      - Rust
-      - Kubernetes
-      - Observability
-      - Energy Metrics
   - title: 30 Days of Terraform
     emoji: ☁️
-    shortDescription: Cloud-agnostic Terraform infrastructure curriculum with Azure depth and AWS validation, covering networking, AKS, RBAC, security patterns, and multi-cloud design.
+    shortDescription: A 30-day self-directed coding challenge repository built with Terraform, implementing progressively complex cloud infrastructure on Azure and AWS, spanning networking, AKS, and RBAC.
     link: 30-days-of-terraform
     techs:
       - Infrastructure as Code

--- a/internal/templates/index.html
+++ b/internal/templates/index.html
@@ -44,27 +44,29 @@
 
     <section class="flex flex-col gap-6">
         <h2 class="text-sm font-bold text-violet-400 tracking-wider uppercase">Featured Projects</h2>
-        <ul class="flex flex-col gap-6 list-none ">
-            {{ range .Config.Projects }}
-            <li>
-                <article class="flex gap-6 p-6 bg-slate-900 border border-slate-800 rounded-xl">
-                    <span role="img" aria-label="{{ .Title }} icon" class="shrink-0 flex items-center justify-center w-16 h-16 bg-slate-800/50 rounded-lg text-4xl">
-                        {{ .Emoji }}
-                    </span>
+        <ul class="grid grid-cols-1 md:grid-cols-2 gap-6 list-none">
+            {{ range $index, $project := .Config.Projects }}
+            <li class="{{ if ge $index 4 }}hidden additional-project transition-all duration-300{{ end }} h-full">
+                <article class="flex flex-col gap-4 p-6 bg-slate-900 border border-slate-800 rounded-xl h-full justify-between">
                     <div class="flex flex-col gap-4">
-                        <div class="flex justify-between items-start">
-                            <h3 class="text-xl font-bold text-slate-100">
-                                {{ .Title }}
+                        <div class="flex items-center gap-4">
+                            <span role="img" aria-label="{{ $project.Title }} icon" class="shrink-0 flex items-center justify-center w-12 h-12 bg-slate-800/50 rounded-lg text-2xl">
+                                {{ $project.Emoji }}
+                            </span>
+                            <h3 class="text-lg font-bold text-slate-100 leading-snug">
+                                {{ $project.Title }}
                             </h3>
                         </div>
-                        <p class="text-slate-400 leading-relaxed text-sm">{{ .ShortDescription }}</p>
-                        <ul class="flex flex-wrap gap-2 list-none ">
-                            {{ range (cleanYAMLList .Techs) }}
+                        <p class="text-slate-400 leading-relaxed text-sm">{{ $project.ShortDescription }}</p>
+                    </div>
+                    <div class="flex flex-col gap-4 mt-auto">
+                        <ul class="flex flex-wrap gap-2 list-none">
+                            {{ range (cleanYAMLList $project.Techs) }}
                             <li class="px-2 py-1 bg-slate-800 text-slate-300 text-xs font-semibold rounded border border-slate-700">{{ . }}</li>
                             {{ end }}
                         </ul>
-                        <div class="mt-2 flex items-center gap-2">
-                            <a href="https://github.com/{{ if eq .Link "platform-actions" }}victoriacheng15hub{{ else }}victoriacheng15{{ end }}/{{ .Link }}#readme" target="_blank" rel="noopener noreferrer" 
+                        <div class="flex items-center gap-2">
+                            <a href="https://github.com/{{ if eq $project.Link "platform-actions" }}victoriacheng15hub{{ else }}victoriacheng15{{ end }}/{{ $project.Link }}#readme" target="_blank" rel="noopener noreferrer" 
                                class="text-violet-400 font-bold hover:text-violet-300 transition-colors group/link flex items-center gap-2 text-sm">
                                 View Project <span class="group-hover/link:translate-x-1 transition-transform">→</span>
                             </a>
@@ -74,6 +76,39 @@
             </li>
             {{ end }}
         </ul>
+
+        {{ if gt (len .Config.Projects) 4 }}
+        <div class="flex justify-center mt-4">
+            <button id="toggle-projects-btn" class="px-6 py-2.5 bg-slate-900 border border-slate-800 hover:border-violet-500/30 text-violet-400 hover:text-violet-300 font-semibold rounded-lg transition-all flex items-center gap-2 text-sm cursor-pointer">
+                <span>View More Projects</span>
+                <svg id="toggle-projects-icon" class="w-4 h-4 transition-transform duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+        </div>
+
+        <script>
+            document.getElementById('toggle-projects-btn').addEventListener('click', function() {
+                const additionalProjects = document.querySelectorAll('.additional-project');
+                const icon = document.getElementById('toggle-projects-icon');
+                const textSpan = this.querySelector('span');
+                const isHidden = additionalProjects[0].classList.contains('hidden');
+
+                additionalProjects.forEach(project => {
+                    project.classList.toggle('hidden');
+                });
+
+                if (isHidden) {
+                    textSpan.textContent = 'View Less';
+                    icon.classList.add('rotate-180');
+                } else {
+                    textSpan.textContent = 'View More Projects';
+                    icon.classList.remove('rotate-180');
+                    document.getElementById('toggle-projects-btn').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                }
+            });
+        </script>
+        {{ end }}
     </section>
 </div>
 {{ end }}


### PR DESCRIPTION
### Summary
This change refactors the projects showcase on the homepage into a premium, responsive two-column grid layout, displaying four projects by default with a View More toggle. It also repairs global mobile container padding, updates the 30 Days of Terraform project description, and refines profile metadata to align with location changes and active projects.

### List of Changes
- Converted the vertical projects list into a responsive two-column grid layout (grid-cols-1 md:grid-cols-2) with equal-height cards and flex-aligned metadata.
- Corrected the malformed global container padding utility class from px- to responsive px-6 md:px-8 in the base page shell.
- Swapped the CarbonOps project with the Dev Toolchain repository, updating technical descriptions, tech tags, and emojis.
- Updated profile.yaml to reflect geographical location changes to the Greater Vancouver Area and refine the list of actively maintained projects.

### Verification
- [x] Run `make build` and `make test` to ensure successful static site compilation and passing unit tests.
- [ ] Verify the collapsible two-column grid alignment and mobile padding gutters in a local web browser.

