### PR TITLE
refactor(generator): parameterize templates and support parallel tests

### DIFF
--- a/cmd/ssg/main.go
+++ b/cmd/ssg/main.go
@@ -33,7 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
 	}
-	gen := internal.New(cfg)
+	gen := internal.New(cfg, "internal/templates")
 
 	// 3. Copy Static Assets
 	if _, err := os.Stat(publicDir); err == nil {

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -15,13 +15,15 @@ import (
 )
 
 type SiteGenerator struct {
-	Config  *contents.SiteConfig
-	FuncMap template.FuncMap
+	Config       *contents.SiteConfig
+	FuncMap      template.FuncMap
+	TemplatesDir string
 }
 
-func New(cfg *contents.SiteConfig) *SiteGenerator {
+func New(cfg *contents.SiteConfig, templatesDir string) *SiteGenerator {
 	return &SiteGenerator{
-		Config: cfg,
+		Config:       cfg,
+		TemplatesDir: templatesDir,
 		FuncMap: template.FuncMap{
 			"split":             strings.Split,
 			"replace":           strings.ReplaceAll,
@@ -63,9 +65,11 @@ func (g *SiteGenerator) RenderPage(dir, filename, tmplPath string, titlePrefix s
 		return fmt.Errorf("failed to create dir %s: %w", dir, err)
 	}
 
-	tmpl, err := template.New("base.html").Funcs(g.FuncMap).ParseFiles("internal/templates/base.html", tmplPath)
+	basePath := filepath.Join(g.TemplatesDir, "base.html")
+	fullTmplPath := filepath.Join(g.TemplatesDir, tmplPath)
+	tmpl, err := template.New("base.html").Funcs(g.FuncMap).ParseFiles(basePath, fullTmplPath)
 	if err != nil {
-		return fmt.Errorf("failed to parse templates for %s: %w", tmplPath, err)
+		return fmt.Errorf("failed to parse templates for %s: %w", fullTmplPath, err)
 	}
 
 	outputFile, err := os.Create(filepath.Join(dir, filename))
@@ -84,7 +88,7 @@ func (g *SiteGenerator) RenderPage(dir, filename, tmplPath string, titlePrefix s
 	data.Title = title
 
 	if err := tmpl.ExecuteTemplate(outputFile, "base.html", data); err != nil {
-		return fmt.Errorf("failed to execute template for %s: %w", tmplPath, err)
+		return fmt.Errorf("failed to execute template for %s: %w", fullTmplPath, err)
 	}
 	return nil
 }
@@ -96,12 +100,12 @@ func (g *SiteGenerator) GenerateStaticPages(distDir string, data *post.ContentDa
 		titlePrefix string
 		data        PageData
 	}{
-		{"index.html", "internal/templates/index.html", "", PageData{}},
-		{"about.html", "internal/templates/about.html", "About", PageData{}},
-		{"now.html", "internal/templates/now.html", "Now", PageData{}},
-		{"404.html", "internal/templates/404.html", "404 - Not Found", PageData{}},
-		{"tags.html", "internal/templates/tags.html", "Tags", PageData{Tags: data.Tags, TagCounts: data.TagCounts}},
-		{"archive.html", "internal/templates/archive.html", "Archive", PageData{Archive: data.PostsByYear, ArchiveYears: data.ArchiveYears}},
+		{"index.html", "index.html", "", PageData{}},
+		{"about.html", "about.html", "About", PageData{}},
+		{"now.html", "now.html", "Now", PageData{}},
+		{"404.html", "404.html", "404 - Not Found", PageData{}},
+		{"tags.html", "tags.html", "Tags", PageData{Tags: data.Tags, TagCounts: data.TagCounts}},
+		{"archive.html", "archive.html", "Archive", PageData{Archive: data.PostsByYear, ArchiveYears: data.ArchiveYears}},
 	}
 
 	for _, p := range pages {
@@ -124,7 +128,7 @@ func (g *SiteGenerator) GenerateBlogPagination(distDir string, data *post.Conten
 		pageNumber := i + 1
 
 		if pageNumber == 1 {
-			if err := g.RenderPage(distDir, "blog.html", "internal/templates/blog.html", "Blog", PageData{
+			if err := g.RenderPage(distDir, "blog.html", "blog.html", "Blog", PageData{
 				Posts:       pagePosts,
 				CurrentPage: pageNumber,
 				TotalPages:  totalPages,
@@ -133,7 +137,7 @@ func (g *SiteGenerator) GenerateBlogPagination(distDir string, data *post.Conten
 			}
 		} else {
 			pageDir := filepath.Join(distDir, "blog")
-			if err := g.RenderPage(pageDir, fmt.Sprintf("%d.html", pageNumber), "internal/templates/blog.html", fmt.Sprintf("Blog - Page %d", pageNumber), PageData{
+			if err := g.RenderPage(pageDir, fmt.Sprintf("%d.html", pageNumber), "blog.html", fmt.Sprintf("Blog - Page %d", pageNumber), PageData{
 				Posts:       pagePosts,
 				CurrentPage: pageNumber,
 				TotalPages:  totalPages,
@@ -149,7 +153,7 @@ func (g *SiteGenerator) GenerateBlogPagination(distDir string, data *post.Conten
 func (g *SiteGenerator) GenerateTagPages(distDir string, data *post.ContentData) error {
 	tagsDistDir := filepath.Join(distDir, "tags")
 	for tag, tagPosts := range data.PostsByTag {
-		if err := g.RenderPage(tagsDistDir, tag+".html", "internal/templates/blog.html", "#"+tag, PageData{
+		if err := g.RenderPage(tagsDistDir, tag+".html", "blog.html", "#"+tag, PageData{
 			Posts:      tagPosts,
 			PathPrefix: "../",
 		}); err != nil {
@@ -163,7 +167,7 @@ func (g *SiteGenerator) GeneratePostPages(distDir string, data *post.ContentData
 	blogDistDir := filepath.Join(distDir, "blog")
 	for _, post := range data.Posts {
 		p := post
-		if err := g.RenderPage(blogDistDir, post.Slug+".html", "internal/templates/post.html", post.Title, PageData{
+		if err := g.RenderPage(blogDistDir, post.Slug+".html", "post.html", post.Title, PageData{
 			Post:       &p,
 			PathPrefix: "../",
 		}); err != nil {

--- a/internal/generator_test.go
+++ b/internal/generator_test.go
@@ -58,7 +58,7 @@ func createTemplates(t *testing.T, dir string) {
 }
 
 func TestFuncMap(t *testing.T) {
-	gen := New(createConfig())
+	gen := New(createConfig(), "")
 
 	tests := []struct {
 		name     string
@@ -122,16 +122,12 @@ func TestFuncMap(t *testing.T) {
 }
 
 func TestRenderPage(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
-	wd, _ := os.Getwd()
-	defer os.Chdir(wd)
-
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
 	createTemplates(t, tmpDir)
 
-	gen := New(createConfig())
+	templatesDir := filepath.Join(tmpDir, "internal", "templates")
+	gen := New(createConfig(), templatesDir)
 	distDir := filepath.Join(tmpDir, "dist")
 
 	tests := []struct {
@@ -146,7 +142,7 @@ func TestRenderPage(t *testing.T) {
 		{
 			name:        "Render Index",
 			filename:    "index.html",
-			tmplPath:    "internal/templates/index.html",
+			tmplPath:    "index.html",
 			titlePrefix: "Home",
 			data:        PageData{},
 			wantErr:     false,
@@ -160,7 +156,7 @@ func TestRenderPage(t *testing.T) {
 		{
 			name:     "Output Dir Creation Failure",
 			filename: "subdir/fail.html",
-			tmplPath: "internal/templates/index.html",
+			tmplPath: "index.html",
 			setup: func() {
 				os.MkdirAll(distDir, 0755)
 				os.WriteFile(filepath.Join(distDir, "subdir"), []byte("block"), 0644)
@@ -189,15 +185,12 @@ func TestRenderPage(t *testing.T) {
 }
 
 func TestGenerators(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
-	wd, _ := os.Getwd()
-	defer os.Chdir(wd)
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
 	createTemplates(t, tmpDir)
 
-	gen := New(createConfig())
+	templatesDir := filepath.Join(tmpDir, "internal", "templates")
+	gen := New(createConfig(), templatesDir)
 	distDir := filepath.Join(tmpDir, "dist")
 
 	posts := []post.Post{
@@ -303,7 +296,7 @@ func TestGenerators(t *testing.T) {
 		{
 			name: "Failure - Missing Template",
 			fn: func() error {
-				if err := os.Remove(filepath.Join(tmpDir, "internal", "templates", "about.html")); err != nil {
+				if err := os.Remove(filepath.Join(templatesDir, "about.html")); err != nil {
 					return err
 				}
 				defer createTemplates(t, tmpDir) // Restore for next tests
@@ -329,10 +322,12 @@ func TestGenerators(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
+	t.Parallel()
 	setup := func(t *testing.T) (string, *SiteGenerator, *post.ContentData) {
 		tmpDir := t.TempDir()
 		createTemplates(t, tmpDir)
-		gen := New(createConfig())
+		templatesDir := filepath.Join(tmpDir, "internal", "templates")
+		gen := New(createConfig(), templatesDir)
 		posts := []post.Post{{Slug: "test", Frontmatter: post.Frontmatter{Title: "T", Date: time.Now()}}}
 		data := &post.ContentData{Posts: posts}
 		return tmpDir, gen, data
@@ -360,11 +355,6 @@ func TestBuild(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir, gen, data := setup(t)
-
-			// We need to change to tmpDir because RenderPage has hardcoded internal/templates
-			wd, _ := os.Getwd()
-			os.Chdir(tmpDir)
-			defer os.Chdir(wd)
 
 			tt.setup(t, tmpDir)
 


### PR DESCRIPTION
### Summary
The site generator constructor is refactored to accept a configurable templates directory path instead of using a hardcoded string. This eliminates the need for process-wide directory changes via `os.Chdir` in the unit tests, resolving race risks and allowing tests to run safely in parallel.

### List of Changes
- Parameterized the template source directory within the site generator structure and constructor.
- Removed directory context switching calls from the rendering, static page generation, and build test suites.
- Enabled concurrent test execution using the standard library's parallel test flag.

### Verification
- [x] Ran standard library tests using `make test` and confirmed all suites passed.
- [x] Verified static analysis checks pass with `make vet`.

