### PR TITLE
refactor(generator): move pipeline to internal and clean cmd entrypoint

### DIFF
--- a/cmd/ssg/main.go
+++ b/cmd/ssg/main.go
@@ -3,13 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"mehub/internal"
-	"mehub/internal/contents"
-	"mehub/internal/post"
-	"mehub/internal/utils"
 )
 
 func main() {
@@ -17,42 +13,14 @@ func main() {
 
 	distDir := "dist"
 	configDir := "internal/templates/contents"
+	templatesDir := "internal/templates"
 	blogDir := "blog"
 	publicDir := "internal/templates/static"
 
-	// 1. Clean and Prepare Dist Directory
-	if err := os.RemoveAll(distDir); err != nil {
-		log.Fatalf("failed to clean dist dir: %v", err)
-	}
-	if err := os.MkdirAll(distDir, 0755); err != nil {
-		log.Fatalf("failed to create dist dir: %v", err)
-	}
-
-	// 2. Load Configuration and Initialize Generator
-	cfg, err := contents.LoadConfig(configDir)
+	count, err := internal.RunPipeline(distDir, configDir, templatesDir, blogDir, publicDir)
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
-	}
-	gen := internal.New(cfg, "internal/templates")
-
-	// 3. Copy Static Assets
-	if _, err := os.Stat(publicDir); err == nil {
-		if err := utils.CopyDir(publicDir, distDir); err != nil {
-			log.Printf("Warning: Failed to copy public assets: %v", err)
-		}
-	}
-
-	// 4. Load and Process Content
-	rawPosts, err := post.GetPosts(blogDir)
-	if err != nil {
-		log.Fatalf("failed to load posts: %v", err)
-	}
-	data := post.ProcessPosts(rawPosts)
-
-	// 5. Build Site
-	if err := gen.Build(distDir, data); err != nil {
 		log.Fatalf("Build failed: %v", err)
 	}
 
-	fmt.Printf("✅ Build completed: generated %d posts in %v\n", len(data.Posts), time.Since(start))
+	fmt.Printf("✅ Build completed: generated %d posts in %v\n", count, time.Since(start))
 }

--- a/internal/pipeline.go
+++ b/internal/pipeline.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"mehub/internal/contents"
+	"mehub/internal/post"
+	"mehub/internal/utils"
+)
+
+// RunPipeline orchestrates the entire site generation flow.
+func RunPipeline(distDir, configDir, templatesDir, blogDir, publicDir string) (int, error) {
+	// 1. Clean and Prepare Dist Directory
+	if err := os.RemoveAll(distDir); err != nil {
+		return 0, fmt.Errorf("failed to clean dist dir: %w", err)
+	}
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		return 0, fmt.Errorf("failed to create dist dir: %w", err)
+	}
+
+	// 2. Load Configuration and Initialize Generator
+	cfg, err := contents.LoadConfig(configDir)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load config: %w", err)
+	}
+	gen := New(cfg, templatesDir)
+
+	// 3. Copy Static Assets
+	if _, err := os.Stat(publicDir); err == nil {
+		if err := utils.CopyDir(publicDir, distDir); err != nil {
+			log.Printf("Warning: Failed to copy public assets: %v", err)
+		}
+	}
+
+	// 4. Load and Process Content
+	rawPosts, err := post.GetPosts(blogDir)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load posts: %w", err)
+	}
+	data := post.ProcessPosts(rawPosts)
+
+	// 5. Build Site
+	if err := gen.Build(distDir, data); err != nil {
+		return 0, fmt.Errorf("build failed: %w", err)
+	}
+
+	return len(data.Posts), nil
+}

--- a/internal/pipeline_test.go
+++ b/internal/pipeline_test.go
@@ -1,0 +1,127 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunPipeline(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	distDir := filepath.Join(tmpDir, "dist")
+	configDir := filepath.Join(tmpDir, "contents")
+	templatesDir := filepath.Join(tmpDir, "templates")
+	blogDir := filepath.Join(tmpDir, "blog")
+	publicDir := filepath.Join(tmpDir, "static")
+
+	// 1. Create dummy configs
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	profileYAML := `
+site:
+  title: "Integration Test Site"
+  url: "https://example.com/"
+  about:
+    paragraphs:
+      - "hello integration"
+`
+	navigationYAML := `
+navigation:
+  header: []
+`
+	socialsYAML := `socials: []`
+	projectsYAML := `projects: []`
+	skillsYAML := `skills: []`
+
+	configs := map[string]string{
+		"profile.yaml":    profileYAML,
+		"navigation.yaml": navigationYAML,
+		"socials.yaml":    socialsYAML,
+		"projects.yaml":   projectsYAML,
+		"skills.yaml":     skillsYAML,
+	}
+	for file, content := range configs {
+		if err := os.WriteFile(filepath.Join(configDir, file), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 2. Create dummy templates
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	baseHTML := `{{ define "base.html" }}<html><body>{{ template "content" . }}</body></html>{{ end }}`
+	pageHTML := `{{ define "content" }}<h1>{{ .Title }}</h1>{{ end }}`
+
+	if err := os.WriteFile(filepath.Join(templatesDir, "base.html"), []byte(baseHTML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	templateFiles := []string{"index.html", "about.html", "now.html", "404.html", "tags.html", "archive.html", "blog.html", "post.html"}
+	for _, f := range templateFiles {
+		if err := os.WriteFile(filepath.Join(templatesDir, f), []byte(pageHTML), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 3. Create dummy blog posts
+	if err := os.MkdirAll(blogDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	postMarkdown := `---
+title: "Integration Post"
+date: 2026-06-11T00:00:00Z
+tags: ["integration"]
+description: "A test post"
+---
+# Hello Integration
+`
+	if err := os.WriteFile(filepath.Join(blogDir, "test.md"), []byte(postMarkdown), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Create public static assets
+	if err := os.MkdirAll(publicDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(publicDir, "test.txt"), []byte("assets"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 5. Run the pipeline
+	count, err := RunPipeline(distDir, configDir, templatesDir, blogDir, publicDir)
+	if err != nil {
+		t.Fatalf("RunPipeline failed: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("Expected 1 post to be built, got %d", count)
+	}
+
+	// 6. Verify outputs exist
+	expectedOutputs := []string{
+		"index.html",
+		"about.html",
+		"now.html",
+		"404.html",
+		"tags.html",
+		"archive.html",
+		"blog.html",
+		"test.txt",
+		"sitemap.xml",
+		"rss.xml",
+		"search-index.json",
+		"llms.txt",
+		filepath.Join("blog", "test.html"),
+		filepath.Join("tags", "integration.html"),
+		filepath.Join("api", "manifest.json"),
+	}
+
+	for _, output := range expectedOutputs {
+		path := filepath.Join(distDir, output)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("Expected output file %s not found: %v", output, err)
+		}
+	}
+}


### PR DESCRIPTION
### Summary
The core static site generation pipeline logic is extracted from the command-line entrypoint to the internal package. This makes the CLI package extremely thin and enables clean integration testing of the entire build pipeline within the internal package.

### List of Changes
- Extracted the build pipeline orchestrator function to the internal package.
- Refactored the CLI main entrypoint to delegate execution to the internal pipeline, reducing its dependency surface.
- Created an end-to-end integration test to verify the generation of all static pages, blogs, sitemaps, registries, and feeds in a clean test environment.

### Verification
- [x] Ran standard library tests using `make test` and confirmed all suites passed.
- [x] Verified static analysis checks pass with `make vet`.

