### PR TITLE
refactor(blog): optimize post tags and standardize taxonomy

### DIFF
--- a/blog/automating-checkboxes-in-google-sheets-with-apps-script.md
+++ b/blog/automating-checkboxes-in-google-sheets-with-apps-script.md
@@ -2,7 +2,7 @@
 title: "Automating Checkboxes in Google Sheets with Apps Script"
 description: "Discover the power of automation in Google Sheets with a guide on adding checkboxes using Apps Script. Simplify tasks and enhance productivity!”. Dive into the full post."
 date: 2024-03-16
-tags: ["automation"]
+tags: ["backend", "javascript"]
 ---
 
 ## What is Google Apps Script?

--- a/blog/binary-decimal-hexadecimal-practical-conversions-guide.md
+++ b/blog/binary-decimal-hexadecimal-practical-conversions-guide.md
@@ -2,7 +2,7 @@
 title: "Binary, Decimal, Hexadecimal - Practical Conversions Guide"
 description: "Learn how computers understand numbers! Dive into decimal, binary, and hexadecimal. Unlock the secrets of coding! Dive into this detailed tutorial to master the core concepts."
 date: 2024-06-18
-tags: ["dsa"]
+tags: ["data-structure"]
 ---
 
 ## Intro to Numerical Systems in Computer

--- a/blog/cloud-elasticity-vs-scalability.md
+++ b/blog/cloud-elasticity-vs-scalability.md
@@ -2,7 +2,7 @@
 title: "🌩️ Cloud – Elasticity vs Scalability"
 description: "Learn the key differences between cloud scalability and elasticity, with clear examples and visual timelines showing how resources adjust over time. Read more to learn."
 date: 2025-10-21
-tags: ["platform", "cloud"]
+tags: ["cloud", "platform"]
 ---
 
 ## What is 🌩️ Cloud – Elasticity vs Scalability?

--- a/blog/cloud-what-is-fault-tolerance.md
+++ b/blog/cloud-what-is-fault-tolerance.md
@@ -2,7 +2,7 @@
 title: "Cloud - What Is Fault Tolerance?"
 description: "Learn what fault tolerance means in cloud computing, how it works through redundancy and recovery, and why it’s key to keeping apps online even when systems fail."
 date: 2025-11-18
-tags: ["platform", "cloud"]
+tags: ["cloud", "platform"]
 ---
 
 ## Cloud — What Is Fault Tolerance? ☁️

--- a/blog/cloud-what-is-high-availability.md
+++ b/blog/cloud-what-is-high-availability.md
@@ -2,7 +2,7 @@
 title: "🌩️ Cloud: What Is High Availability"
 description: "Learn High Availability in the cloud: how redundancy, load balancing, and failover keep your applications online with minimal downtime. Explore this comprehensive guide."
 date: 2025-11-04
-tags: ["platform", "cloud"]
+tags: ["cloud", "kubernetes", "platform"]
 ---
 
 ## 🧠 Understanding High Availability

--- a/blog/coding-challenges-what-i-learned-from-write-your-wc-tool.md
+++ b/blog/coding-challenges-what-i-learned-from-write-your-wc-tool.md
@@ -2,7 +2,7 @@
 title: "Coding Challenges: What I Learned From Write Your wc Tool?"
 description: "Dive into coding challenges with 'Write Your Own wc tool.' Explore TDD, classes in JavaScript, and utilities like spyOn and process.stdin. Read the full guide to learn."
 date: 2024-01-11
-tags: ["dsa", "javascript"]
+tags: ["data-structure", "javascript"]
 ---
 
 ## Coding Challenges - Write Your Own wc tool

--- a/blog/data-structure-hash-tables.md
+++ b/blog/data-structure-hash-tables.md
@@ -2,7 +2,7 @@
 title: "Data Structure - Hash Tables"
 description: "Discover hash tables, a fast data structure for quick retrieval. Learn how they work, handle collisions, and their applications in databases, caches, and more. Read on."
 date: 2024-07-16
-tags: ["dsa"]
+tags: ["data-structure"]
 ---
 
 ## What is a Hash Table?

--- a/blog/data-structure-linked-list.md
+++ b/blog/data-structure-linked-list.md
@@ -2,7 +2,7 @@
 title: "Data Structure - Linked List"
 description: "Dive into the basics of linked lists: understand how they work, their operations, and explore two key types. Dive into this detailed tutorial to master the core concepts."
 date: 2024-05-07
-tags: ["dsa"]
+tags: ["data-structure"]
 ---
 
 ## What is a Linked List?

--- a/blog/data-structure-queues.md
+++ b/blog/data-structure-queues.md
@@ -2,7 +2,7 @@
 title: "Data Structure - Queues"
 description: "Explore the essence of queues: understand FIFO principle, real-life analogies, and implement in JavaScript and Python. Elevate your data structure skills! Read more to learn."
 date: 2024-04-24
-tags: ["dsa"]
+tags: ["data-structure", "javascript", "python"]
 ---
 
 ## What is a Queue?

--- a/blog/data-structure-stacks.md
+++ b/blog/data-structure-stacks.md
@@ -2,7 +2,7 @@
 title: "Data Structure - Stacks"
 description: "Discover the power of stacks in data structures—efficiency and versatility in handling Last In, First Out (LIFO) operations. Discover essential tips and practical guides."
 date: 2024-04-18
-tags: ["dsa"]
+tags: ["data-structure", "javascript", "python"]
 ---
 
 ## What is a Stack?

--- a/blog/doubly-linked-list-javascript-code-example.md
+++ b/blog/doubly-linked-list-javascript-code-example.md
@@ -2,7 +2,7 @@
 title: "Doubly Linked List - JavaScript Code Example"
 description: "Doubly linked lists facilitate bidirectional traversal, offering insertion, deletion, and search operations with nodes linking forward and backward. Read more to learn."
 date: 2024-06-04
-tags: ["dsa"]
+tags: ["data-structure", "javascript"]
 ---
 
 ## What is a Doubly Linked List?

--- a/blog/engineering-log-cron-vs-systemd-a-deep-dive.md
+++ b/blog/engineering-log-cron-vs-systemd-a-deep-dive.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Cron vs. Systemd: A Deep Dive"
 description: "A deep dive into Systemd vs Cron: Automating an observability hub with self-healing timers, centralized logging, and dependency management. Read the full guide to learn."
 date: 2026-02-03
-tags: ["retrospective", "linux", "automation"]
+tags: ["linux", "platform", "retrospective"]
 ---
 
 ## 1. Context (The "Why")

--- a/blog/engineering-log-killing-the-static-env-with-openbao.md
+++ b/blog/engineering-log-killing-the-static-env-with-openbao.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Killing the Static .env with OpenBao"
 description: "Eliminating static .env files by centralizing secrets in OpenBao via a reusable internal/secrets module, decoupling credentials to streamline the Kubernetes migration phase."
 date: 2026-03-03
-tags: ["retrospective", "platform"]
+tags: ["kubernetes", "platform", "retrospective"]
 ---
 
 ## 1. Context (The "Why")

--- a/blog/engineering-log-measuring-memory-value-in-echo.md
+++ b/blog/engineering-log-measuring-memory-value-in-echo.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Measuring Memory Value in Echo"
 description: "Adding local FinOps and Knowledge ROI analytics to Echo so persistent memory can measure cost, hit rate, carbon estimates, and low-signal context before quality drifts."
 date: 2026-06-16
-tags: ["go", "retrospective"]
+tags: ["mcp", "observability", "retrospective"]
 ---
 
 ## Context

--- a/blog/engineering-log-migrating-python-cli-to-serverless.md
+++ b/blog/engineering-log-migrating-python-cli-to-serverless.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Migrating Python CLI to Serverless"
 description: "Why I migrated a local Python CLI script to an Azure Serverless Function to eliminate virtual environment friction and gain practical hands-on cloud experience."
 date: 2026-02-24
-tags: ["retrospective", "python", "cloud"]
+tags: ["cloud", "python", "retrospective"]
 ---
 
 ## 1. Context (The "Why")

--- a/blog/engineering-log-persistent-ai-memory-with-echo.md
+++ b/blog/engineering-log-persistent-ai-memory-with-echo.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Persistent AI Memory with Echo"
 description: "Building an MCP server with Go and SQLite to give AI agents scoped, local-first memory, reduce repeated context setup, and keep project decisions available in CLI sessions."
 date: 2026-04-14
-tags: ["go", "retrospective", "mcp"]
+tags: ["go", "mcp", "retrospective"]
 ---
 
 ## Context

--- a/blog/engineering-log-the-brittle-json-grafana-provisioning-failure.md
+++ b/blog/engineering-log-the-brittle-json-grafana-provisioning-failure.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] The Brittle JSON: Grafana Provisioning Failure"
 description: "Fixing Grafana dashboard provisioning by moving from brittle embedded JSON in values.yaml to standalone files, resolving 'invalid character' bugs once and for all."
 date: 2026-04-07
-tags: ["retrospective", "platform"]
+tags: ["kubernetes", "observability", "retrospective"]
 ---
 
 ## Context

--- a/blog/engineering-log-the-migration-strangler-promtail-to-alloy.md
+++ b/blog/engineering-log-the-migration-strangler-promtail-to-alloy.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] The Migration Strangler: Promtail to Alloy"
 description: "Migrating from EOL Promtail to Grafana Alloy via a Strangler Fig pattern, bridging Kubernetes and Docker logs to ensure zero visibility loss during the platform transition."
 date: 2026-03-10
-tags: ["retrospective", "platform", "kubernetes"]
+tags: ["kubernetes", "observability", "retrospective"]
 ---
 
 ## Context

--- a/blog/engineering-log-the-phased-migration-to-kubernetes.md
+++ b/blog/engineering-log-the-phased-migration-to-kubernetes.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] The Phased Migration to Kubernetes"
 description: "Executing a risk-based, four-stage migration of the observability stack from Docker to Kubernetes to ensure data integrity and system stability."
 date: 2026-03-17
-tags: ["retrospective", "platform", "kubernetes"]
+tags: ["kubernetes", "observability", "retrospective"]
 ---
 
 ## Context

--- a/blog/engineering-log-why-i-swapped-vue-for-go.md
+++ b/blog/engineering-log-why-i-swapped-vue-for-go.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Swapping Vue for Go"
 description: "Rebuilding a Linktree-style Vue project as a Go static site generator to reduce npm maintenance, simplify builds, and learn Go through a small real-world publishing tool."
 date: 2026-04-21
-tags: ["retrospective", "go"]
+tags: ["go", "retrospective"]
 ---
 
 ## Context

--- a/blog/engineering-log-why-not-index-everything.md
+++ b/blog/engineering-log-why-not-index-everything.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] Why Not Index Everything?"
 description: "An investigation into B-Trees, the library analogy, and why we don't index every column. Discover essential tips, full code examples, and practical insights in this guide."
 date: 2026-01-13
-tags: ["retrospective", "backend"]
+tags: ["backend", "retrospective"]
 ---
 
 ## 1. Context (The "Why")

--- a/blog/from-links-to-reading-insights.md
+++ b/blog/from-links-to-reading-insights.md
@@ -2,7 +2,7 @@
 title: "From Links to Reading Insights"
 description: "From article extractor to personal reading analytics dashboard—zero infrastructure, Go-powered metrics, and live visualizations on GitHub Pages. Dive into the full post."
 date: 2026-01-06
-tags: ["growth", "go"]
+tags: ["go", "growth"]
 ---
 
 ## What is From Links to Reading Insights?

--- a/blog/from-metrics-to-milestones.md
+++ b/blog/from-metrics-to-milestones.md
@@ -2,7 +2,7 @@
 title: "From Metrics to Milestones"
 description: "Visualizing a project’s journey: a product-first landing page and a timeline generated from a structured YAML history of milestones. Dive into this step-by-step tutorial."
 date: 2026-01-20
-tags: ["growth", "go"]
+tags: ["go", "growth"]
 ---
 
 ## What is From Metrics to Milestones?

--- a/blog/gitops-from-timers-to-webhooks.md
+++ b/blog/gitops-from-timers-to-webhooks.md
@@ -2,7 +2,7 @@
 title: "GitOps: From Timers to Webhooks"
 description: "From systemd timers to event-driven webhooks: How I leveraged a Go proxy to eliminate O(N) management toil and achieve instant GitOps syncs for multiple repositories."
 date: 2026-02-17
-tags: ["go", "automation"]
+tags: ["go", "platform"]
 ---
 
 ## The Systemd Approach

--- a/blog/ipv4-vs-ipv6-a-quick-guide.md
+++ b/blog/ipv4-vs-ipv6-a-quick-guide.md
@@ -2,7 +2,7 @@
 title: "IPv4 vs IPv6: A Quick Guide"
 description: "Explore the key differences between IPv4 and IPv6, focusing on address size, security, and performance, and understand their impact on the internet. Read more to learn."
 date: 2024-08-20
-tags: ["platform"]
+tags: ["cloud", "platform"]
 ---
 
 ## Understanding the Internet Protocol (IP)

--- a/blog/nextjs-state-management-with-redux-toolkit-part-1.md
+++ b/blog/nextjs-state-management-with-redux-toolkit-part-1.md
@@ -2,7 +2,7 @@
 title: Nextjs State Management with Redux Toolkit - Part 1
 description: "This guide provides a step-by-step process for setting up Redux Toolkit with Next.js, enabling you to easily manage state in your web applications. Dive into the full post."
 date: 2023-04-12
-tags: ["frontend"]
+tags: ["frontend", "typescript"]
 ---
 
 ## Intro

--- a/blog/nextjs-state-management-with-redux-toolkit-part-2.md
+++ b/blog/nextjs-state-management-with-redux-toolkit-part-2.md
@@ -2,7 +2,7 @@
 title: Nextjs State Management with Redux Toolkit - Part 2
 description: "Part 1 covered setting up Redux Toolkit and topSlice function and then how would I refactor the codebase to make it cleaner and more readable way. Dive into the full post."
 date: 2023-04-19
-tags: ["frontend"]
+tags: ["frontend", "typescript"]
 ---
 
 ## Intro

--- a/blog/optimizing-kubernetes-telemetry-via-ebpf.md
+++ b/blog/optimizing-kubernetes-telemetry-via-ebpf.md
@@ -2,7 +2,7 @@
 title: "Optimizing Kubernetes Telemetry via eBPF"
 description: "Deploying eBPF, Cilium, and Kepler resolves the high CPU overhead of agent-based monitoring while establishing precise Joules-level sustainability telemetry in Kubernetes."
 date: 2026-06-09
-tags: ["kubernetes", "linux"]
+tags: ["kubernetes", "linux", "observability"]
 ---
 
 ## Kernel-Level Telemetry Architecture

--- a/blog/react-hooks-usecallback.md
+++ b/blog/react-hooks-usecallback.md
@@ -2,7 +2,7 @@
 title: React Hooks - useCallback
 description: "Boost React app performance with useCallback hook. Understand how it works, prevent re-renders & compare examples with/without useCallback. Read the full guide to learn."
 date: 2023-01-18
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## What is useCallback?

--- a/blog/react-hooks-usecontext.md
+++ b/blog/react-hooks-usecontext.md
@@ -2,7 +2,7 @@
 title: React Hooks - useContext
 description: "Access global state in functional components with useContext hook in React 16.8. Avoid prop drilling & consume context efficiently. Dive into this step-by-step tutorial."
 date: 2023-01-04
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## What is useContext?

--- a/blog/react-hooks-useeffect.md
+++ b/blog/react-hooks-useeffect.md
@@ -2,7 +2,7 @@
 title: React Hooks - useEffect
 description: "Learn to use useEffect in React for side effects such as fetching data, event listeners, etc. Control hook call with dependency array & use with diff values. Read on."
 date: 2022-12-14
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## What is useEffect?

--- a/blog/react-hooks-usememo.md
+++ b/blog/react-hooks-usememo.md
@@ -2,7 +2,7 @@
 title: "React Hooks - useMemo"
 description: "Optimize React app performance with useMemo hook. Learn advantages disadvantages & see performance difference with before/after examples. Explore this comprehensive guide."
 date: 2023-01-11
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## What is useMemo?

--- a/blog/react-hooks-usereducer.md
+++ b/blog/react-hooks-usereducer.md
@@ -2,7 +2,7 @@
 title: React Hooks - useReducer
 description: "Manage state changes & fetch API data with useReducer in React. More flexible than useState, takes reducer & initial state, returns state & dispatch function. Read on."
 date: 2022-12-21
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## What is useReducer Hook?

--- a/blog/react-hooks-useref.md
+++ b/blog/react-hooks-useref.md
@@ -2,7 +2,7 @@
 title: "React Hooks - useRef"
 description: "React's useRef hook: Handles mutable values & DOM interaction, curbs re-renders, boosts performance. Explore practical examples and step-by-step insights to learn more."
 date: 2023-08-23
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## What is useRef?

--- a/blog/react-hooks-usestate.md
+++ b/blog/react-hooks-usestate.md
@@ -2,7 +2,7 @@
 title: React Hooks - useState
 description: "Learn to use useState in React to handle data types, avoid mutability in arrays & update state values. Bonus: TypeScript & handling state logging behavior. Read more to learn."
 date: 2022-12-06
-tags: ["frontend"]
+tags: ["frontend", "typescript"]
 ---
 
 ## What is useState?

--- a/blog/react-pagination-vanilla-edition.md
+++ b/blog/react-pagination-vanilla-edition.md
@@ -2,7 +2,7 @@
 title: React Pagination - Vanilla Edition
 description: "Create React pagination with 5 pages, navigation buttons, current page highlight, and centered navigation. No external packages needed. Demo & code provided. Read on."
 date: 2022-11-06
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## Intro

--- a/blog/refactoring-for-an-mcp-ready-ecosystem.md
+++ b/blog/refactoring-for-an-mcp-ready-ecosystem.md
@@ -2,7 +2,7 @@
 title: "MCP-Ready Ecosystem Refactor"
 description: "Transitioning from fragmented multi-module scripts to a library-first platform using a unified Go workspace."
 date: 2026-03-31
-tags: ["platform", "system-design", "go"]
+tags: ["go", "mcp", "system-design"]
 ---
 
 ## The Mission: Architectural Maturity

--- a/blog/scaling-with-systemd-template-units.md
+++ b/blog/scaling-with-systemd-template-units.md
@@ -2,7 +2,7 @@
 title: "Scaling with Systemd Template Units"
 description: "Learn to scale Linux automation using Systemd Template Units. Discover how the '@' symbol and gitops-sync timers simplify service management. Read the full guide to learn."
 date: 2026-02-10
-tags: ["retrospective", "linux"]
+tags: ["linux", "retrospective"]
 ---
 
 ## The Discovery: Deciphering the '@' Symbol

--- a/blog/simplifying-big-o-notation-a-guide-to-algorithm-efficiency.md
+++ b/blog/simplifying-big-o-notation-a-guide-to-algorithm-efficiency.md
@@ -2,7 +2,7 @@
 title: "Simplifying Big O Notation - A Guide to Algorithm Efficiency"
 description: "Unlock efficient coding with our guide to Big O notation. Learn to optimize algorithms for superior performance in software engineering. Explore this comprehensive guide."
 date: 2024-01-16
-tags: ["dsa"]
+tags: ["data-structure", "javascript"]
 ---
 
 ## Understanding Big O Notation

--- a/blog/singly-linked-list-javascript-code-example.md
+++ b/blog/singly-linked-list-javascript-code-example.md
@@ -2,7 +2,7 @@
 title: "Singly Linked List - JavaScript Code Example"
 description: "Explore Singly Linked Lists with concise code examples in JavaScript, mastering insertion, deletion, and search operations. Discover essential tips and practical guides."
 date: 2024-05-14
-tags: ["dsa"]
+tags: ["data-structure", "javascript"]
 ---
 
 ## What is a Singly Linked List?

--- a/blog/ssl-and-tls-explained-for-secure-communication.md
+++ b/blog/ssl-and-tls-explained-for-secure-communication.md
@@ -2,7 +2,7 @@
 title: "SSL and TLS Explained for Secure Communication"
 description: "Learn how SSL/TLS secures online communication, protects your data, and ensures privacy. Understand the handshake process and its importance in simple terms. Read on."
 date: 2025-04-01
-tags: ["platform"]
+tags: ["cloud", "platform"]
 ---
 
 ## What is SSL or TLS?

--- a/blog/system-design-content-delivery-networks.md
+++ b/blog/system-design-content-delivery-networks.md
@@ -2,7 +2,7 @@
 title: "System Design - Content Delivery Networks"
 description: "Unveiling Content Delivery Networks (CDNs): Simplifying internet speed with mini-library-like networks. Faster, safer, smoother browsing. Explore this comprehensive guide."
 date: 2024-04-16
-tags: ["system-design"]
+tags: ["cloud", "system-design"]
 ---
 
 ## What is Content Delivery Networks (CDNs)?

--- a/blog/systemic-reliability-sli-vs-slo-patterns.md
+++ b/blog/systemic-reliability-sli-vs-slo-patterns.md
@@ -2,7 +2,7 @@
 title: "Systemic Reliability: SLI vs SLO Patterns"
 description: "An objective analysis of Service Level Indicators and Objectives, detailing the architectural transition from raw metrics to business-aligned reliability targets for scale."
 date: 2026-06-02
-tags: ["platform", "system-design"]
+tags: ["observability", "platform", "system-design"]
 ---
 
 ## The Operational Bottleneck of Subjectivity

--- a/blog/the-sre-era-standardizing-opentelemetry.md
+++ b/blog/the-sre-era-standardizing-opentelemetry.md
@@ -2,7 +2,7 @@
 title: "The SRE Era: Standardizing OpenTelemetry"
 description: "Mastering SRE principles by transitioning from ad-hoc data collection to a standardized OpenTelemetry ecosystem using Prometheus, Grafana Tempo, and MinIO for persistence."
 date: 2026-03-24
-tags: ["platform", "system-design", "kubernetes"]
+tags: ["cloud", "kubernetes", "observability"]
 ---
 
 ## The Shift: From "Working" to "Standardized"

--- a/blog/the-terraform-era-declarative-automation.md
+++ b/blog/the-terraform-era-declarative-automation.md
@@ -2,7 +2,7 @@
 title: "The Terraform Era: Declarative Automation"
 description: "Transitioning from imperative Makefile scripting to a declarative OpenTofu orchestration layer for managing a growing Kubernetes observability stack through Infrastructure as Code."
 date: 2026-04-28
-tags: ["platform", "kubernetes", "terraform"]
+tags: ["kubernetes", "observability", "terraform"]
 ---
 
 ## The Shift: From Scripting to Orchestration

--- a/blog/trying-azure-blob-storage.md
+++ b/blog/trying-azure-blob-storage.md
@@ -2,7 +2,7 @@
 title: "Trying Azure Blob Storage"
 description: "How I loaded CSV data from Azure Blob Storage in a school project—with local fallback and no hardcoded secrets. Dive into this detailed tutorial to master the core concepts."
 date: 2025-12-23
-tags: ["platform", "cloud"]
+tags: ["cloud", "platform", "python"]
 ---
 
 ## What is Azure Blob Storage?

--- a/blog/trying-azure-container-registry.md
+++ b/blog/trying-azure-container-registry.md
@@ -2,7 +2,7 @@
 title: "Trying Azure Container Registry"
 description: "Learn how I used Azure Container Registry to securely store Docker images from a personal project, with GitHub Actions CI and zero hardcoded secrets. Read more to learn."
 date: 2025-12-16
-tags: ["platform", "cloud"]
+tags: ["cloud", "platform"]
 ---
 
 ## What is Azure Container Registry?

--- a/blog/understanding-apis-rest-vs-graphql.md
+++ b/blog/understanding-apis-rest-vs-graphql.md
@@ -2,7 +2,7 @@
 title: "Understanding APIs: REST vs GraphQL"
 description: "Learn the key differences between REST and GraphQL APIs, their pros and cons, and when to use each for your project. Read this comprehensive guide to learn much more."
 date: 2025-09-02
-tags: ["system-design"]
+tags: ["javascript", "system-design"]
 ---
 
 ## Introduction

--- a/blog/understanding-http-methods-and-status.md
+++ b/blog/understanding-http-methods-and-status.md
@@ -2,7 +2,7 @@
 title: "Understanding HTTP Methods and Status"
 description: "Learn the essentials of HTTP methods (GET, POST, PUT, PATCH, DELETE) and common status codes to build clear, effective APIs. Discover essential tips and practical guides."
 date: 2025-08-12
-tags: ["platform"]
+tags: ["javascript", "platform"]
 ---
 
 ## What is HTTP Methods and Status?

--- a/blog/understanding-node-js-event-loop-efficiency.md
+++ b/blog/understanding-node-js-event-loop-efficiency.md
@@ -2,7 +2,7 @@
 title: "Understanding Node.js Event Loop Efficiency"
 description: "Understand how Node.js's event loop and non-blocking I/O efficiently manage concurrent tasks in a single-threaded environment for high-performance apps. Read more to learn."
 date: 2024-07-02
-tags: ["backend"]
+tags: ["backend", "javascript"]
 ---
 
 ## What is the Node.js Event Loop?

--- a/blog/understanding-nosql-vs-sql-databases.md
+++ b/blog/understanding-nosql-vs-sql-databases.md
@@ -2,7 +2,7 @@
 title: "Understanding NoSQL vs SQL Databases"
 description: "Discover the contrasts between NoSQL and SQL databases: NoSQL for flexibility and scalability, SQL for relational integrity and transaction reliability. Read more to learn."
 date: 2024-06-11
-tags: ["backend"]
+tags: ["backend", "cloud"]
 ---
 
 ## NoSQL vs SQL

--- a/blog/understanding-the-osi-reference-model.md
+++ b/blog/understanding-the-osi-reference-model.md
@@ -2,7 +2,7 @@
 title: "Understanding the OSI Reference Model"
 description: "Overview of the OSI Reference Model: Learn about the seven layers, their functions, and how they enable seamless network communication between diverse systems. Read on."
 date: 2024-07-09
-tags: ["platform"]
+tags: ["cloud", "platform"]
 ---
 
 ## What is the OSI Reference Model?

--- a/blog/unified-intelligence-for-observability-hub.md
+++ b/blog/unified-intelligence-for-observability-hub.md
@@ -2,7 +2,7 @@
 title: "Unified Intelligence for Observability Hub"
 description: "Transitioning to Agentic Infrastructure via the Model Context Protocol unified gateway, providing specialized tools for automated RCA across telemetry, pods, network flows, and gateway capability state."
 date: 2026-05-05
-tags: ["observability", "mcp", "platform"]
+tags: ["mcp", "observability", "platform"]
 ---
 
 ## Solving the Cognitive Telemetry Gap

--- a/blog/use-azure-key-vault-for-secrets.md
+++ b/blog/use-azure-key-vault-for-secrets.md
@@ -2,7 +2,7 @@
 title: "Use Azure Key Vault for Secrets"
 description: "Securely manage app secrets in Azure using Key Vault—store credentials like GitHub OAuth IDs safely and handle local development with smart fallbacks. Read more to learn."
 date: 2025-12-09
-tags: ["platform", "cloud"]
+tags: ["cloud", "platform", "python"]
 ---
 
 ## What is Key Vault in Azure?

--- a/blog/what-have-i-learned-about-react-context-api.md
+++ b/blog/what-have-i-learned-about-react-context-api.md
@@ -2,7 +2,7 @@
 title: What Have I Learned About React Context API
 description: "Explore React's Context API for sharing data among components without props drilling. Demo includes search, region filter, pagination, and theme switcher. Read more to learn."
 date: 2022-10-28
-tags: ["frontend"]
+tags: ["frontend", "javascript"]
 ---
 
 ## Context API

--- a/blog/what-is-a-garbage-collection.md
+++ b/blog/what-is-a-garbage-collection.md
@@ -2,7 +2,7 @@
 title: "What is a Garbage Collection"
 description: "Learn about garbage collection: the process of reclaiming unused memory in programming, with a deep dive into JavaScript's automated memory management. Read more to learn."
 date: 2024-12-10
-tags: ["system-design"]
+tags: ["javascript", "system-design"]
 ---
 
 

--- a/internal/templates/contents/projects.yaml
+++ b/internal/templates/contents/projects.yaml
@@ -39,6 +39,7 @@ projects:
       - Automation
       - Bash
       - Agentic Enablement
+      - Developer Workflows
   - title: Observability Hub
     emoji: 📊
     shortDescription: End-to-end Kubernetes observability system using Terraform and GitOps, with OpenTelemetry, eBPF networking, MCP diagnostics, HA data services, and incident workflows including ADRs and RCAs.


### PR DESCRIPTION
### Summary
Standardizes the post tag taxonomy across all blog posts in the repository. It updates taxonomy classifications, guarantees required tags on engineering logs, and caps all posts at a maximum of 3 tags to maximize discoverability and reduce visual clutter. It also updates project technologies in the portfolio metadata configuration.

### List of Changes
- Standardized and updated tags across 56 blog posts to enforce the strict 3-tag limit and ensure taxonomy consistency.
- Updated project technologies in the portfolio metadata configuration file.

### Verification
- [x] Ran `make build` successfully.
- [x] Passed `make vet` and `make test`.

