### PR TITLE
refactor(go): optimize formatting target scopes and update agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This document provides context and instructions for AI agents working on the **M
 
 **Mehub** is a personal website and blog platform built with a custom Go-based SSG. It emphasizes performance, zero external runtime dependencies, and AI-first discoverability.
 
-- **Core Tech**: Go (Golang) 1.23.4
+- **Core Tech**: Go (Golang) 1.26
 - **Styling**: Tailwind CSS (standalone CLI)
 - **Content**: Markdown with YAML frontmatter
 - **Architecture**: Single-binary generator that renders templates into a `dist/` directory.
@@ -23,17 +23,38 @@ This document provides context and instructions for AI agents working on the **M
 
 ## 3. Build and Development
 
-The project uses a `Makefile` that automatically wraps commands in `nix-shell` if available.
+The project uses a `Makefile` to orchestrate build, test, and formatting tasks.
+
+### Site Generation
 
 | Command | Description |
 | :--- | :--- |
 | `make build` | **Primary Command**. Downloads Tailwind, builds the SSG, and generates the full site in `dist/`. |
-| `make test` | Runs all Go unit tests. |
-| `make check` | Verifies code formatting (`gofmt`) and static analysis (`go vet`). |
-| `make format` | Automatically formats all Go code. |
-| `make lint` | Lints all Markdown files using `markdownlint`. |
-| `make add-hr` | Helper script to insert horizontal rules (`---`) between H2 headings in blog posts. |
+
+### Development
+
+| Command | Description |
+| :--- | :--- |
 | `make update` | Updates Go dependencies and tidies `go.mod`. |
+| `make vet` | Verifies code formatting (`gofmt`) and static analysis (`go vet`) under `cmd/` and `internal/`. |
+| `make format` | Formats all Go code under `cmd/` and `internal/` using `go fmt` and `goimports`. |
+| `make test` | Runs Go unit tests under `internal/`. |
+| `make test-cov` | Runs Go unit tests with coverage report under `internal/`. |
+
+### Markdown Files
+
+| Command | Description |
+| :--- | :--- |
+| `make md-lint` | Lints all Markdown files using `markdownlint-cli`. |
+| `make md-format` | Automatically formats all Markdown files using `markdownlint-cli`. |
+
+### Setup
+
+| Command | Description |
+| :--- | :--- |
+| `make setup-tailwind` | Downloads and sets up the Tailwind CSS CLI locally. |
+| `make setup-go` | Downloads and sets up Go locally. |
+| `make ssg-build` | Sets up Go and Tailwind CLI, then builds the SSG. |
 
 ## 4. AI Discoverability & API Registries
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo "Setup:"
 	@echo "  setup-tailwind  Download Tailwind CLI (Linux x64)"
 	@echo "  setup-go        Download and setup Go locally"
-	@echo "  ssg-build       Setup Go and Tailwind, then build (for Vercel deployment)"
+	@echo "  ssg-build       Setup Go and Tailwind, then build the SSG"
 	@echo ""
 	@echo "Utility:"
 	@echo "  help            Show this help message"

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 
 require (
 	github.com/alecthomas/chroma/v2 v2.26.1 // indirect
-	github.com/dlclark/regexp2/v2 v2.1.1 // indirect
+	github.com/dlclark/regexp2/v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dlclark/regexp2/v2 v2.1.1 h1:LCUGyd9Wf+r+VVOl8Ny38JTpWJcAsdVnCIuhhtthmKw=
-github.com/dlclark/regexp2/v2 v2.1.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dlclark/regexp2/v2 v2.2.2 h1:MYWvNYw8okuqNhwTYO587EZMiDruVa2vhV6fsGpfya0=
+github.com/dlclark/regexp2/v2 v2.2.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/mk/go.mk
+++ b/mk/go.mk
@@ -1,29 +1,30 @@
-GO_VERSION=1.25.0
+GO_VERSION=1.26.0
 GO_TAR=go$(GO_VERSION).linux-amd64.tar.gz
 GO_DIR=./go-dist
 
 .PHONY: format update vet test test-cov setup-go lint
 
-format:
-	go fmt ./...
-
 update:
 	go get -u ./... && go mod tidy
 
 vet:
-	@go vet ./...
-	@if [ -n "$$(gofmt -l .)" ]; then \
+	@go vet ./cmd/... ./internal/...
+	@if [ -n "$$(gofmt -l cmd/ internal/)" ]; then \
 		echo "Go code is not formatted. Please run 'make format':"; \
-		gofmt -l .; \
+		gofmt -l cmd/ internal/; \
 		exit 1; \
 	fi
 	@echo "✅ Go code is formatted correctly and vetted."
 
+format:
+	go fmt ./cmd/... ./internal/...
+	~/go/bin/goimports -local mehub -w cmd/ internal/
+
 test:
-	go test -v ./...
+	go test -v ./internal/...
 
 test-cov:
-	go test -coverprofile=coverage.out ./... && \
+	go test -coverprofile=coverage.out ./internal/... && \
 	go tool cover -func=coverage.out && \
 	rm coverage.out
 


### PR DESCRIPTION
### Summary
The Go build, formatting, and test targets previously operated on the entire module globally, which risked traversing temporary Go setup distributions. This change restricts Go formatting, vetting, and import checks to the `cmd/` and `internal/` directories, limits tests to `internal/`, and updates the agent onboarding guide to match these optimized target definitions.

### List of Changes
- Narrow the scope of `go fmt`, `gofmt`, and `go vet` targets to the `cmd/` and `internal/` directories.
- Integrate `goimports` into the `format` target to automatically sort and group local package imports.
- Update agent guidelines and developer commands in `AGENTS.md` to document target folders and Go 1.26 runtime requirements.

### Verification
- [x] Ran `make vet test` to verify static analysis, formatting, and unit tests pass successfully.

