### PR TITLE
chore(ci): isolate e2e path triggers and filter conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - '**/*.go'
+      - 'cmd/**/*.go'
+      - 'internal/**/*.go'
+      - 'e2e/**/*'
       - 'go.mod'
       - 'go.sum'
       - '**/*.md'
@@ -20,6 +22,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       markdown: ${{ steps.filter.outputs.markdown }}
+      e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -27,11 +30,16 @@ jobs:
         with:
           filters: |
             go:
-              - '**/*.go'
+              - 'cmd/**/*.go'
+              - 'internal/**/*.go'
               - 'go.mod'
               - 'go.sum'
             markdown:
               - '**/*.md'
+            e2e:
+              - 'e2e/**/*'
+              - 'go.mod'
+              - 'go.sum'
 
   check:
     runs-on: ubuntu-latest
@@ -58,6 +66,19 @@ jobs:
 
       - name: Run Tests
         run: make test
+
+  test-bdd:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.go-version }}
+
+      - name: Run BDD Tests
+        run: make test-bdd
 
   markdownlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary
Isolate E2E BDD test job execution within the continuous integration workflow. This ensures BDD testing is triggered specifically by changes inside the `e2e/` directory or shared dependencies, running independently from standard unit test jobs.

### List of Changes
- Restructure CI paths filter to detect E2E directory changes independently.
- Configure `test-bdd` to evaluate E2E filter conditions rather than wildcard Go filters.
- Ensure dependency modifications (go.mod and go.sum) trigger both unit testing and BDD integration testing.

### Verification
- Verify workflow file structure and paths syntax in `.github/workflows/ci.yml`

