### PR TITLE
refactor(blog): retire mermaid diagrams and switch to ascii art

### DIFF
--- a/blog/astro-builds-with-mermaid-diagrams.md
+++ b/blog/astro-builds-with-mermaid-diagrams.md
@@ -23,10 +23,8 @@ The fix was to add a custom build workflow that installs Playwright so Astro can
 
 I used `rehype-mermaid` to transform code blocks into diagrams during the build:
 
-```mermaid
-graph LR
-  A --> B
-  B --> C
+```text
+  [ A ] ──> [ B ] ──> [ C ]
 ```
 
 But once deployed, the page went blank. Not just the diagram — all content disappeared. No errors. No warnings.

--- a/blog/cloud-elasticity-vs-scalability.md
+++ b/blog/cloud-elasticity-vs-scalability.md
@@ -23,12 +23,14 @@ Imagine you run a web app on a single server. As traffic grows, you deploy a sec
 
 #### Diagram: Scalability (grows but doesn’t shrink)
 
-```mermaid
-timeline
-    title Scalability Timeline (4 Hours)
-    0h : Server1 runs
-    2h : Server2 added (peak traffic)
-    4h : End (Server2 remains)
+```text
+Scalability Timeline (4 Hours)
+┌───────┬─────────────────┬───────────────────────────────┬───────────────────────────────┐
+│ Time  │ 0h              │ 2h (Peak Traffic)             │ 4h (End)                      │
+├───────┼─────────────────┼───────────────────────────────┼───────────────────────────────┤
+│ State │ [Server 1] runs │ [Server 2] added              │ [Server 2] remains            │
+│       │                 │ [Server 1] runs               │ [Server 1] runs               │
+└───────┴─────────────────┴───────────────────────────────┴───────────────────────────────┘
 ```
 
 ---
@@ -45,15 +47,14 @@ On Black Friday, your cloud app might automatically scale from 5 servers to 50 s
 
 #### Diagram: Elasticity (auto scale up and down)
 
-```mermaid
-timeline
-    title Elasticity Timeline (4 Hours)
-    0h : Server1 runs
-    2h : Server2 added
-    2h : Server3 added
-    3h : Server2 removed
-    3h : Server3 removed
-    4h : End (only Server1 remains)
+```text
+Elasticity Timeline (4 Hours)
+┌───────┬─────────────────┬─────────────────────────────────┬─────────────────────────────────┬───────────────────┐
+│ Time  │ 0h              │ 2h                              │ 3h                              │ 4h (End)          │
+├───────┼─────────────────┼─────────────────────────────────┼─────────────────────────────────┼───────────────────┤
+│ State │ [Server 1] runs │ [Server 2] & [Server 3] added   │ [Server 2] & [Server 3] removed │ [Server 1] remains│
+│       │                 │ [Server 1] runs                 │ [Server 1] runs                 │                   │
+└───────┴─────────────────┴─────────────────────────────────┴─────────────────────────────────┴───────────────────┘
 ```
 
 ---

--- a/blog/cloud-what-is-high-availability.md
+++ b/blog/cloud-what-is-high-availability.md
@@ -45,14 +45,14 @@ This design ensures that the system continues to operate — maybe with slightly
 
 Here’s a simplified view of how that looks:
 
-```mermaid
-graph LR
-  A[User Requests] --> LB[Load Balancer]
-  LB --> S1[Server - Zone A]
-  LB --> S2[Server - Zone B]
-  S1 --> DB[(Database Cluster)]
-  S2 --> DB
-  DB --> B[(Backup Storage)]
+```text
+  ┌──────┐      ┌───────────────┐      ┌─────────────────┐
+  │ User │ ───> │               │ ───> │ Server - Zone A │ ───┐
+  └──────┘      │               │      └─────────────────┘    │
+                │ Load Balancer │                             │ ──> ┌──────────────────┐      ┌────────────────┐
+                │               │      ┌─────────────────┐    │     │ Database Cluster │ ───> │ Backup Storage │
+                │               │ ───> │ Server - Zone B │ ───┘     └──────────────────┘      └────────────────┘
+                └───────────────┘      └─────────────────┘
 ```
 
 ✅ **Explanation:**  

--- a/blog/exploring-alias-linux-commands.md
+++ b/blog/exploring-alias-linux-commands.md
@@ -15,14 +15,33 @@ The basic syntax of the `alias` command:
 alias new_command="original_command"
 ```
 
-```mermaid
-graph TD
-    A[Create Alias] --> B{Where is it defined?}
-    B -->|Command Line| C[Temporary Alias]
-    C --> D[Lost on Terminal Close]
-    B -->|Configuration File| E[Permanent Alias]
-    E -->|e.g., ~/.bashrc or ~/.zshrc| F[Loads on New Session]
-    F --> G[Persists Across Sessions]
+```text
+                     ┌──────────────┐
+                     │ Create Alias │
+                     └──────────────┘
+                             │
+                             ▼
+                 /───────────────────────\
+                <  Where is it defined?   >
+                 \───────────────────────/
+                   /                   \
+         (Command Line)             (Configuration File)
+                 /                       \
+                ▼                         ▼
+      ┌─────────────────┐       ┌─────────────────┐
+      │ Temporary Alias │       │ Permanent Alias │
+      └─────────────────┘       └─────────────────┘
+                │                         │
+                ▼                         ▼
+      ┌─────────────────┐       ┌─────────────────┐
+      │ Lost on Close   │       │ Loads on New    │
+      └─────────────────┘       │ Session         │
+                                └─────────────────┘
+                                          │
+                                          ▼
+                                ┌─────────────────┐
+                                │ Persists        │
+                                └─────────────────┘
 ```
 
 ---

--- a/blog/exploring-chgrp-linux-commands.md
+++ b/blog/exploring-chgrp-linux-commands.md
@@ -23,13 +23,22 @@ chgrp developers project.txt
 
 This command changes the group ownership of `project.txt` to the `developers` group.
 
-```mermaid
-graph LR
-    A[File/Directory] --> B(User/Owner)
-    A --> C(Group)
-    A --> D(Others)
-    C -->|Permissions Match| E[Group Members]
-    C -.->|Admin Modified via| F[chgrp Command]
+```text
+                      ┌───────────────┐
+                ┌───> │  User/Owner   │
+                │     └───────────────┘
+                │     ┌───────────────┐       ┌───────────────┐
+  ┌──────────┐  ├───> │     Group     │ ────> │ Group Members │
+  │   File   │  │     └───────────────┘       └───────────────┘
+  │    or    │  │             :
+  │Directory │  │             : (Admin Modified via)
+  └──────────┘  │             v
+                │     ┌───────────────┐
+                ├───> │   chgrp Cmd   │
+                │     └───────────────┘
+                │     ┌───────────────┐
+                └───> │    Others     │
+                      └───────────────┘
 ```
 
 ---

--- a/blog/from-links-to-reading-insights.md
+++ b/blog/from-links-to-reading-insights.md
@@ -38,13 +38,44 @@ To answer these, I moved beyond raw data and built a metrics engine that compute
 
 Here is how it works today:
 
-```mermaid
-graph TD
-    A["Article Extraction<br/>Python"] -->|Extract & Deduplicate| B["Google Sheets<br/>(Central Reading List)"]
-    B -->|Read Articles| C["Metrics Calculation<br/>(Go → metrics/YYYY-MM-DD.json)"]
-    C -->|Load Latest| D["Dashboard Generator<br/>Go + html/template"]
-    D -->|Render HTML| E["Static HTML Page"]
-    E -->|Deploy| F["GitHub Pages"]
+```text
+  ┌──────────────────────┐
+  │  Article Extraction  │
+  │       (Python)       │
+  └──────────────────────┘
+             │
+             │ (Extract & Deduplicate)
+             ▼
+  ┌──────────────────────┐
+  │    Google Sheets     │
+  │ (Central Read List)  │
+  └──────────────────────┘
+             │
+             │ (Read Articles)
+             ▼
+  ┌──────────────────────┐
+  │ Metrics Calculation  │
+  │  (Go → metrics.json) │
+  └──────────────────────┘
+             │
+             │ (Load Latest)
+             ▼
+  ┌──────────────────────┐
+  │ Dashboard Generator  │
+  │ (Go + html/template) │
+  └──────────────────────┘
+             │
+             │ (Render HTML)
+             ▼
+  ┌──────────────────────┐
+  │   Static HTML Page   │
+  └──────────────────────┘
+             │
+             │ (Deploy)
+             ▼
+  ┌──────────────────────┐
+  │     GitHub Pages     │
+  └──────────────────────┘
 ```
 
 ---

--- a/blog/how-to-trigger-workflows-between-repos.md
+++ b/blog/how-to-trigger-workflows-between-repos.md
@@ -154,16 +154,32 @@ jobs:
 
 ### How it Works (Diagram)
 
-```mermaid
-flowchart TD
-    A[Draft Blog Repo: Issue Created with 'trigger' Label] --> B[Trigger: Workflow in Draft Repo]
-    B --> C[Send repository_dispatch to Public Blog Repo]
-    C --> D[Public Blog Repo Workflow Runs]
-    D --> E[Fetch Blog Content via API]
-    E --> F[Create Branch & Commit Post]
-    F --> G{PR Exists?}
-    G -- Yes --> H[Do Nothing]
-    G -- No --> I[Create Pull Request for New Blog Post]
+```text
+[Draft Blog Repo: Issue Created with 'trigger' Label]
+                        |
+                        v
+          [Trigger: Workflow in Draft Repo]
+                        |
+                        v
+    [Send repository_dispatch to Public Blog Repo]
+                        |
+                        v
+        [Public Blog Repo Workflow Runs]
+                        |
+                        v
+          [Fetch Blog Content via API]
+                        |
+                        v
+         [Create Branch & Commit Post]
+                        |
+                        v
+                 /-------------\
+                <  PR Exists?   >
+                 \-------------/
+                   /         \
+            Yes   /           \  No
+                 v             v
+          [Do Nothing]    [Create Pull Request]
 ```
 
 ---

--- a/blog/understanding-data-modeling.md
+++ b/blog/understanding-data-modeling.md
@@ -65,65 +65,69 @@ How entities relate to each other. For example, a `User` can have many `Orders`.
 
 ### Conceptual Model Diagram
 
-```mermaid
-erDiagram
-    CUSTOMER ||--o{ ORDER : places
-    ORDER ||--o{ PRODUCT : contains
-    CUSTOMER {
-        string Name
-        string Email
-    }
-    PRODUCT {
-        string ProductName
-        float Price
-    }
-
+```text
+  +--------------+          places          +-----------+
+  |   CUSTOMER   | 1 ----------------- 0..* |   ORDER   |
+  +--------------+                          +-----------+
+  | string Name  |                                | 1
+  | string Email |                                |
+  +--------------+                                | contains
+                                                  |
+                                            0..*  v
+                                            +--------------+
+                                            |   PRODUCT    |
+                                            +--------------+
+                                            | string Name  |
+                                            | float Price  |
+                                            +--------------+
 ```
 
 ### Logical Model Diagram
 
-```mermaid
-erDiagram
-    Customer {
-        int CustomerID PK
-        string Name
-        string Email
-    }
-    Order {
-        int OrderID PK
-        date OrderDate
-        int CustomerID FK
-    }
-    Product {
-        int ProductID PK
-        string ProductName
-        decimal Price
-    }
-    Customer ||--o{ Order : places
-    Order ||--o{ Product : contains
+```text
+  +------------------+          places          +------------------+
+  |     Customer     | 1 ----------------- 0..* |      Order       |
+  +------------------+                          +------------------+
+  | CustomerID (PK)  |                          | OrderID (PK)     |
+  | Name             |                          | OrderDate        |
+  | Email            |                          | CustomerID (FK)  |
+  +------------------+                          +------------------+
+                                                          | 1
+                                                          |
+                                                          | contains
+                                                          |
+                                                    0..*  v
+                                                    +------------------+
+                                                    |     Product      |
+                                                    +------------------+
+                                                    | ProductID (PK)   |
+                                                    | ProductName      |
+                                                    | Price            |
+                                                    +------------------+
 ```
 
 ### Physical Model Diagram
 
-```mermaid
-erDiagram
-    customers {
-        SERIAL customer_id PK
-        VARCHAR name
-        VARCHAR email
-    }
-    orders {
-        SERIAL order_id PK
-        DATE order_date
-        INT customer_id FK
-    }
-    products {
-        SERIAL product_id PK
-        VARCHAR product_name
-        NUMERIC price
-    }
-    customers ||--o{ orders : places
-    orders ||--o{ products : contains
+```text
+  +--------------------+          places          +--------------------+
+  |     customers      | 1 ----------------- 0..* |       orders       |
+  +--------------------+                          +--------------------+
+  | customer_id (PK)   |                          | order_id (PK)      |
+  | name (VARCHAR)     |                          | order_date (DATE)  |
+  | email (VARCHAR)    |                          | customer_id (FK)   |
+  +--------------------+                          +--------------------+
+                                                             | 1
+                                                             |
+                                                             | contains
+                                                             |
+                                                       0..*  v
+                                                       +--------------------+
+                                                       |     products       |
+                                                       +--------------------+
+                                                       | product_id (PK)    |
+                                                       | product_name (VAR) |
+                                                       | price (NUMERIC)    |
+                                                       +--------------------+
 ```
 
 ---

--- a/blog/what-i-learned-about-python-decorators.md
+++ b/blog/what-i-learned-about-python-decorators.md
@@ -83,12 +83,20 @@ Decorators let you move that shared logic into one place.
 
 Here’s the overall idea:
 
-```mermaid
-flowchart TD
-    A[You call your function] --> B[Decorator intercepts the call]
-    B --> C[Run extra logic like validation, logging]
-    C --> D[Execute original function]
-    D --> E[Return decorated result]
+```text
+  [ You call your function ]
+              |
+              v
+ [ Decorator intercepts call ]
+              |
+              v
+ [ Run extra logic (e.g. logs) ]
+              |
+              v
+ [ Execute original function ]
+              |
+              v
+ [ Return decorated result ]
 ```
 
 Decorators are perfect for things like:

--- a/internal/content.go
+++ b/internal/content.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -14,8 +13,6 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 	"gopkg.in/yaml.v3"
 )
-
-var mermaidRegex = regexp.MustCompile(`(?s)<pre><code class="language-mermaid">.*?</code></pre>`)
 
 // LoadConfig reads and parses all YAML files under configDir, populating a SiteConfig.
 func LoadConfig(configDir string) (*SiteConfig, error) {
@@ -79,11 +76,6 @@ func ParsePost(path string) (*Post, error) {
 	}
 
 	content := buf.String()
-	content = mermaidRegex.ReplaceAllStringFunc(content, func(m string) string {
-		inner := strings.TrimPrefix(m, `<pre><code class="language-mermaid">`)
-		inner = strings.TrimSuffix(inner, `</code></pre>`)
-		return `<div class="mermaid">` + inner + `</div>`
-	})
 
 	slug := strings.TrimSuffix(filepath.Base(path), ".md")
 

--- a/internal/content_test.go
+++ b/internal/content_test.go
@@ -140,22 +140,7 @@ This is a test.
 			},
 			wantErr: false,
 		},
-		{
-			name:     "Mermaid Diagram Replacement",
-			filename: "mermaid.md",
-			content: `---
-title: "Mermaid"
----
-<pre><code class="language-mermaid">graph TD; A-->B;</code></pre>
-`,
-			validate: func(t *testing.T, post *Post) {
-				expected := `<div class="mermaid">graph TD; A-->B;</div>`
-				if !strings.Contains(post.Content, expected) {
-					t.Errorf("Expected mermaid div, got: %s", post.Content)
-				}
-			},
-			wantErr: false,
-		},
+
 		{
 			name:     "Invalid Frontmatter",
 			filename: "invalid_fm.md",

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -4,13 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
     <!-- SEO -->
     <title>{{ .Title }}</title>
     <meta name="description"
         content="{{ if .Post }}{{ .Post.Description }}{{ else }}{{ .Config.Site.Slogan }}{{ end }}">
     <link rel="canonical" href="{{ .Config.Site.URL }}{{ if .Post }}blog/{{ .Post.Slug }}.html{{ end }}">
-
     <!-- Open Graph / Social -->
     <meta property="og:type" content="{{ if .Post }}article{{ else }}website{{ end }}">
     <meta property="og:url" content="{{ .Config.Site.URL }}{{ if .Post }}blog/{{ .Post.Slug }}.html{{ end }}">
@@ -35,18 +33,13 @@
     }
     </script>
     {{ end }}
-
     <!-- RSS Feed Discovery -->
     <link rel="alternate" type="application/rss+xml" title="{{ .Config.Site.Title }} RSS Feed"
         href="{{ .PathPrefix }}rss.xml">
 
     <link rel="icon" type="image/svg+xml" href="{{ .PathPrefix }}favicon.svg">
     <link href="{{ .PathPrefix }}styles.css" rel="stylesheet">
-
-    <!-- Performance: Defer heavy scripts -->
-    <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
 </head>
-
 <body class="bg-slate-950 text-slate-200 font-sans antialiased min-h-screen flex flex-col items-center">
     <div class="w-full max-w-3xl flex flex-col min-h-screen gap-12 px-6 md:px-8 py-10">
         {{ template "header" . }}
@@ -57,13 +50,9 @@
 
         {{ template "footer" . }}
     </div>
-    <script>
-        mermaid.initialize({ startOnLoad: true });
-    </script>
 </body>
 
 </html>
-
 {{ define "header" }}
 <header class="w-full flex flex-col sm:flex-row justify-between items-center gap-4 pb-6 border-b border-violet-500/20">
     <div class="flex flex-col items-center sm:items-start">
@@ -102,7 +91,6 @@
             <p>&copy; {{ .CurrentYear }} 🐧 {{ .Config.Site.Title }}. All rights reserved.</p>
         </div>
     </div>
-
     <div class="flex flex-col items-center sm:items-end gap-6">
         <div class="flex gap-4">
             {{ range .Config.Socials }}


### PR DESCRIPTION
### Summary
Retire the Mermaid diagram rendering architecture completely in favor of plain-text ASCII art. This transition simplifies the generator codebase, removes runtime browser JavaScript dependencies, and makes all diagrams fully searchable and grepable.

### List of Changes
- Replaced Mermaid flowchart and ER diagrams with ASCII art equivalents in 9 blog posts.
- Removed regex parsing logic and unused imports from the Go content package.
- Removed the Mermaid JS library import and initialization block from the main layout template.

### Verification
- [x] `make test`
- [x] `make test-bdd`
- [x] `make format vet`

