### PR TITLE
feat(ui): render open source contributions below tech stack

### DIFF
--- a/internal/templates/index.html
+++ b/internal/templates/index.html
@@ -42,6 +42,71 @@
         </ul>
     </section>
 
+    {{ if .Config.Contributions }}
+    <section class="flex flex-col gap-6">
+        <h2 class="text-sm font-bold text-violet-400 tracking-wider uppercase">Open Source Contributions</h2>
+        <ul class="flex flex-col gap-6 list-none">
+            {{ range $cIndex, $contrib := .Config.Contributions }}
+            <li>
+                <article class="flex flex-col gap-4 p-6 bg-slate-900 border border-slate-800 rounded-xl">
+                    <div class="flex flex-col gap-2">
+                        <h3 class="text-lg font-bold text-slate-100">
+                            <a href="{{ $contrib.Link }}" target="_blank" rel="noopener noreferrer" class="hover:text-violet-400 transition-colors">
+                                {{ $contrib.Repo }}
+                            </a>
+                        </h3>
+                        <p class="text-slate-400 text-sm leading-relaxed">{{ $contrib.Description }}</p>
+                    </div>
+
+                    <div class="h-px bg-slate-800/50 my-2"></div>
+
+                    <ul class="flex flex-col gap-3 list-none pl-4 border-l border-slate-800">
+                        {{ range $prIndex, $pr := $contrib.PRs }}
+                        <li class="{{ if ge $prIndex 5 }}hidden additional-pr-{{ $cIndex }} transition-all duration-300{{ end }}">
+                            <a href="{{ $contrib.Link }}/pull/{{ $pr.Number }}" target="_blank" rel="noopener noreferrer" class="group flex items-start gap-2 text-sm">
+                                <span class="text-slate-500 font-mono shrink-0 group-hover:text-violet-400 transition-colors">#{{ $pr.Number }}</span>
+                                <span class="text-slate-300 group-hover:text-violet-400 transition-colors leading-snug">{{ $pr.Title }}</span>
+                            </a>
+                        </li>
+                        {{ end }}
+                    </ul>
+
+                    {{ if gt (len $contrib.PRs) 5 }}
+                    <div class="mt-2">
+                        <button class="toggle-prs-btn text-xs font-semibold text-violet-400 hover:text-violet-300 transition-colors cursor-pointer flex items-center gap-1"
+                                data-repo-index="{{ $cIndex }}">
+                            <span>see more ↓</span>
+                        </button>
+                    </div>
+                    {{ end }}
+                </article>
+            </li>
+            {{ end }}
+        </ul>
+    </section>
+
+    <script>
+        document.querySelectorAll('.toggle-prs-btn').forEach(button => {
+            button.addEventListener('click', function() {
+                const cIndex = this.getAttribute('data-repo-index');
+                const additionalPRs = document.querySelectorAll('.additional-pr-' + cIndex);
+                const textSpan = this.querySelector('span');
+                const isHidden = additionalPRs[0].classList.contains('hidden');
+
+                additionalPRs.forEach(pr => {
+                    pr.classList.toggle('hidden');
+                });
+
+                if (isHidden) {
+                    textSpan.textContent = 'see less ↑';
+                } else {
+                    textSpan.textContent = 'see more ↓';
+                }
+            });
+        });
+    </script>
+    {{ end }}
+
     <section class="flex flex-col gap-6">
         <h2 class="text-sm font-bold text-violet-400 tracking-wider uppercase">Featured Projects</h2>
         <ul class="flex flex-col gap-6 list-none">

--- a/scripts/fetch_contributions.py
+++ b/scripts/fetch_contributions.py
@@ -50,18 +50,19 @@ def query_github_api(url: str) -> dict:
 
 def fetch_external_pull_requests() -> list[dict]:
     """Retrieve all external pull requests authored by the user from GitHub API."""
-    search_query = urllib.parse.quote(f"author:{USERNAME} type:pr -user:{USERNAME}")
     pull_requests = []
     
-    # Iterate through pagination pages (max 10 pages)
-    for page in range(1, 11):
-        url = f"https://api.github.com/search/issues?q={search_query}&per_page=100&page={page}"
-        payload = query_github_api(url)
-        page_items = payload.get("items", [])
-        pull_requests.extend(page_items)
-        if len(page_items) < 100:
-            break
-            
+    # Query open and merged PRs separately to exclude closed/unmerged ones
+    for state_filter in ["is:open", "is:merged"]:
+        search_query = urllib.parse.quote(f"author:{USERNAME} type:pr -user:{USERNAME} {state_filter}")
+        for page in range(1, 11):
+            url = f"https://api.github.com/search/issues?q={search_query}&per_page=100&page={page}"
+            payload = query_github_api(url)
+            page_items = payload.get("items", [])
+            pull_requests.extend(page_items)
+            if len(page_items) < 100:
+                break
+                
     return pull_requests
 
 


### PR DESCRIPTION
### Summary
Expose and render the personal open source contributions block on the portfolio home page immediately below the tech stack. The section displays repositories, descriptions, and pull requests, with an interactive "see more" toggle to expand lists beyond 5 entries. The accompanying fetcher script has been refactored to be standard-library based and queries only open or merged pull requests.

### List of Changes
- Render the Open Source Contributions block in index.html with inline expansion and collapse capabilities.
- Fetch and group pull requests filtering only open or merged contributions in the fetcher script.

### Verification
- [x] Run `make test-all` to ensure all backend Go unit tests and BDD tests pass successfully.
- [x] Execute `make build` to verify Tailwind CSS building and HTML rendering compile with no errors.

