### PR TITLE
fix(blog): highlight active tag filter

### DIFF
--- a/internal/templates/blog.html
+++ b/internal/templates/blog.html
@@ -2,7 +2,7 @@
 <div class="flex flex-col gap-10">
     <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-6">
         {{ if stringsHasPrefix .Title "#" }}
-        {{ $tag := index (split .Title " | ") 0 }}
+        {{ $tag := stringsTrimPrefix (index (split .Title " | ") 0) "#" }}
         <h1 class="text-3xl font-bold text-violet-400">Tag: {{ $tag }}</h1>
         {{ else }}
         <h1 class="text-3xl font-bold text-violet-400">Blog</h1>
@@ -25,7 +25,7 @@
         {{ range .Tags }}
         {{ $active := false }}
         {{ if stringsHasPrefix $.Title "#" }}
-            {{ $currentTag := stringsTrimPrefix $.Title "#" }}
+            {{ $currentTag := stringsTrimPrefix (index (split $.Title " | ") 0) "#" }}
             {{ if eq $currentTag . }}
                 {{ $active = true }}
             {{ end }}


### PR DESCRIPTION
### Summary
Tag pages were not highlighting the selected filter because the active-state comparison used the full rendered page title instead of the raw tag name. This change normalizes the tag title before display and comparison so the selected blog tag receives the expected active styling.

### List of Changes
- Restore visual feedback for active blog tag filters so readers can see which topic view is selected.
- Keep the fix scoped to the blog template, reducing review surface and avoiding unrelated generated or planning files.

### Verification
- [x] make vet
- [x] make test
- [x] make build

