### PR TITLE
refactor(archive): simplify post list layout

### DIFF
--- a/internal/templates/archive.html
+++ b/internal/templates/archive.html
@@ -2,10 +2,10 @@
 <div class="flex flex-col gap-12">
     <h1 class="text-3xl font-bold text-violet-400">Archive</h1>
     
-    <div class="flex flex-col gap-10">
+    <div class="flex flex-col gap-6">
         {{ range .ArchiveYears }}
         {{ $year := . }}
-        <details class="flex flex-col gap-6" {{ if eq $year $.CurrentYear }}open{{ end }}>
+        <details class="flex flex-col gap-4" {{ if eq $year $.CurrentYear }}open{{ end }}>
             <summary class="flex items-center justify-between cursor-pointer list-none group/year">
                 <h2 class="text-2xl font-bold text-slate-100 group-hover/year:text-violet-400 transition-colors">{{ $year }}</h2>
                 <span class="text-slate-500 transform group-open:rotate-180 transition-transform duration-200">
@@ -14,13 +14,13 @@
                     </svg>
                 </span>
             </summary>
-            <ul class="flex flex-col gap-4 list-none">
+            <ul class="flex flex-col gap-2 list-none">
                 {{ range (index $.Archive $year) }}
                 <li>
                     <article>
-                        <a href="blog/{{ .Slug }}.html" class="flex items-center gap-6 p-4 bg-slate-900 border border-slate-800 rounded-xl hover:border-violet-500/30 transition-all group/post">
-                            <time class="text-sm text-slate-500 font-bold uppercase tracking-wider whitespace-nowrap">{{ .Date.Format "Jan 02" }}</time>
-                            <h3 class="font-bold text-slate-200 group-hover/post:text-violet-400 transition-colors">
+                        <a href="blog/{{ .Slug }}.html" class="flex flex-col gap-1 transition-colors group/post sm:flex-row sm:items-baseline sm:gap-6">
+                            <time class="text-xs text-slate-500 font-bold uppercase tracking-wider whitespace-nowrap sm:w-16">{{ .Date.Format "Jan 02" }}</time>
+                            <h3 class="text-base font-semibold text-slate-200 group-hover/post:text-violet-400 transition-colors">
                                 {{ .Title }}
                             </h3>
                         </a>


### PR DESCRIPTION
### Summary
The archive page used card-style post entries, which made an index-style page feel heavier than needed. This change simplifies the archive into a lighter text list so older posts are easier to scan by date and title.

### List of Changes
- Removes the boxed archive post treatment in favor of compact text rows with quieter metadata.
- Keeps the change isolated to the archive template, making the visual adjustment straightforward to review.

### Verification
- [x] Run `make vet`
- [x] Run `make build` for local dev site

