### PR TITLE
fix(theme): resolve duplicate slate color and clean unused colors

### DIFF
--- a/internal/templates/404.html
+++ b/internal/templates/404.html
@@ -2,7 +2,7 @@
 <div class="flex flex-col items-center justify-center gap-12 py-20 text-center">
     <div class="flex flex-col gap-4">
         <h1 class="text-8xl font-extrabold text-violet-400">404</h1>
-        <h2 class="text-2xl font-bold text-slate-100 uppercase tracking-widest">Page Not Found</h2>
+        <h2 class="text-2xl font-bold text-slate-200 uppercase tracking-widest">Page Not Found</h2>
     </div>
     
     <p class="text-lg text-slate-400 max-w-md leading-relaxed">

--- a/internal/templates/about.html
+++ b/internal/templates/about.html
@@ -9,7 +9,7 @@
 
     <!-- Timeline Section -->
     <section class="flex flex-col gap-4" aria-labelledby="timeline-heading">
-        <h2 id="timeline-heading" class="text-lg font-bold text-slate-100">Timeline:</h2>
+        <h2 id="timeline-heading" class="text-lg font-bold text-slate-200">Timeline:</h2>
         <ul class="list-disc list-inside text-slate-300 flex flex-col gap-2 leading-relaxed text-sm md:text-base">
             {{ range (cleanYAMLList .Config.About.Timeline) }}
             <li>{{ . | safeHTML }}</li>
@@ -21,7 +21,7 @@
     <section class="flex flex-col gap-4" aria-labelledby="currently-heading">
         <div class="flex flex-col gap-1">
             <span class="text-xs text-slate-500 font-normal uppercase tracking-wider">Last updated: {{ .Config.About.LastUpdated }}</span>
-            <h2 id="currently-heading" class="text-lg font-bold text-slate-100">Currently doing:</h2>
+            <h2 id="currently-heading" class="text-lg font-bold text-slate-200">Currently doing:</h2>
         </div>
         <ul class="list-disc list-inside text-slate-300 flex flex-col gap-2 leading-relaxed text-sm md:text-base">
             {{ range (cleanYAMLList .Config.About.Currently) }}

--- a/internal/templates/archive.html
+++ b/internal/templates/archive.html
@@ -7,7 +7,7 @@
         {{ $year := . }}
         <details class="flex flex-col gap-4" {{ if eq $year $.CurrentYear }}open{{ end }}>
             <summary class="flex items-center justify-between cursor-pointer list-none group/year">
-                <h2 class="text-2xl font-bold text-slate-100 group-hover/year:text-violet-400 transition-colors">{{ $year }}</h2>
+                <h2 class="text-2xl font-bold text-slate-200 group-hover/year:text-violet-400 transition-colors">{{ $year }}</h2>
                 <span class="text-slate-500 transform group-open:rotate-180 transition-transform duration-200">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />

--- a/internal/templates/index.html
+++ b/internal/templates/index.html
@@ -50,7 +50,7 @@
             <li>
                 <article class="flex flex-col gap-4 p-6 bg-slate-900 border border-slate-800 rounded-xl">
                     <div class="flex flex-col gap-2">
-                        <h3 class="text-lg font-bold text-slate-100">
+                        <h3 class="text-lg font-bold text-slate-200">
                             <a href="{{ $contrib.Link }}" target="_blank" rel="noopener noreferrer" class="hover:text-violet-400 transition-colors">
                                 {{ $contrib.Repo }}
                             </a>
@@ -130,7 +130,7 @@
                             <span role="img" aria-label="{{ $project.Title }} icon" class="shrink-0 flex items-center justify-center w-12 h-12 bg-slate-800/50 rounded-lg text-2xl">
                                 {{ $project.Emoji }}
                             </span>
-                            <h3 class="text-lg font-bold text-slate-100 leading-snug">
+                            <h3 class="text-lg font-bold text-slate-200 leading-snug">
                                 {{ $project.Title }}
                             </h3>
                         </div>

--- a/internal/templates/input.css
+++ b/internal/templates/input.css
@@ -3,30 +3,19 @@
 
 @theme {
   /* Foundation (Slate) */
-  --color-slate-50: #f8fafc;
   --color-slate-100: #f1f5f9;
   --color-slate-200: #e2e8f0;
   --color-slate-300: #cbd5e1;
   --color-slate-400: #94a3b8;
-  --color-slate-50: #64748b;
-  --color-slate-600: #475569;
   --color-slate-700: #334155;
   --color-slate-800: #1e293b;
   --color-slate-900: #0f172a;
   --color-slate-950: #020617;
 
   /* Accent (Violet) */
-  --color-violet-50: #f5f3ff;
-  --color-violet-100: #ede9fe;
-  --color-violet-200: #ddd6fe;
   --color-violet-300: #c4b5fd;
   --color-violet-400: #a78bfa;
   --color-violet-500: #8b5cf6;
-  --color-violet-600: #7c3aed;
-  --color-violet-700: #6d28d9;
-  --color-violet-800: #5b21b6;
-  --color-violet-900: #4c1d95;
-  --color-violet-950: #2e1065;
 
   /* Typography Colors (Prose Overrides for Violet Theme) */
   --tw-prose-body: var(--color-slate-200);

--- a/internal/templates/post.html
+++ b/internal/templates/post.html
@@ -2,7 +2,7 @@
 <article class="flex flex-col gap-10 text-slate-200">
     <header class="flex flex-col gap-6">
         <time class="text-sm text-slate-500 uppercase tracking-wider font-bold">{{ .Post.Date.Format "January 02, 2006" }}</time>
-        <h1 class="text-4xl font-extrabold text-slate-100 leading-tight">{{ .Post.Title }}</h1>
+        <h1 class="text-4xl font-extrabold text-slate-200 leading-tight">{{ .Post.Title }}</h1>
         <ul class="flex gap-3 list-none">
             {{ range .Post.Tags }}
             <li class="px-2 py-1 bg-slate-800 text-slate-300 text-xs font-semibold rounded border border-slate-700">#{{ . }}</li>


### PR DESCRIPTION
### Summary
This change resolves a duplicate definition of `--color-slate-50` in the CSS theme settings that was causing the light slate color to be overridden by a darker gray. Additionally, unused color definitions were removed, and other instances of `slate-100` in templates were standardized to `slate-200` to match the design hierarchy while preserving it for code block text.

### List of Changes
- Resolve the CSS theme override bug by removing the duplicate `--color-slate-50` definition.
- Clean up the theme stylesheet by removing unused slate and violet shades to keep theme variables focused.
- Standardize heading elements in template files to use `slate-200` instead of `slate-100` for color hierarchy consistency.

### Verification
- [x] Run `make build` locally to compile Tailwind CSS stylesheet and generate the static files successfully.

