### PR TITLE
feat(scripts): fetch only authored issues for contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,223 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Pythoni se
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+*.lcov
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi/*
+!.pixi/config.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule*
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+# Temporary file for partial code execution
+tempCodeRunnerFile.py
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/scripts/fetch_contributions.py
+++ b/scripts/fetch_contributions.py
@@ -19,7 +19,7 @@ import urllib.request
 # Configuration settings
 USERNAME = os.environ.get("GITHUB_USER", "victoriacheng15")
 API_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-REPOS = ["chaos-mesh/chaos-mesh"]
+REPOS = ["chaos-mesh/chaos-mesh",  "cncf/open-community-groups", "cucumber/godog"]
 
 # API base headers (preserving custom User-Agent)
 HEADERS = {
@@ -202,22 +202,19 @@ def generate_contributions_yaml(contributions: list[dict]) -> str:
 
 
 def fetch_external_issues() -> list[dict]:
-    """Retrieve issues authored or commented on by the user from GitHub API."""
-    issues_map = {}
+    """Retrieve issues authored by the user from GitHub API."""
+    issues = []
     repo_filters = " ".join(f"repo:{repo}" for repo in REPOS)
     
-    # Query authored and commented issues separately to bypass API query limitations
-    for filter_term in [f"author:{USERNAME}", f"commenter:{USERNAME}"]:
-        search_query = urllib.parse.quote(f"type:issue {filter_term} {repo_filters}".strip())
-        for page in range(1, 6):
-            url = f"https://api.github.com/search/issues?q={search_query}&per_page=100&page={page}"
-            payload = query_github_api(url)
-            page_items = payload.get("items", [])
-            for item in page_items:
-                issues_map[item["html_url"]] = item
-            if len(page_items) < 100:
-                break
-    return list(issues_map.values())
+    search_query = urllib.parse.quote(f"type:issue author:{USERNAME} {repo_filters}".strip())
+    for page in range(1, 6):
+        url = f"https://api.github.com/search/issues?q={search_query}&per_page=100&page={page}"
+        payload = query_github_api(url)
+        page_items = payload.get("items", [])
+        issues.extend(page_items)
+        if len(page_items) < 100:
+            break
+    return issues
 
 
 def main() -> None:


### PR DESCRIPTION
### Summary
Refines the external contribution fetcher script to retrieve only issues authored by the user, filtering out issues where the user only commented. This reduces clutter and ensures that the projects page only lists high-signal contributions.

### List of Changes
- Refined the GitHub Search query in the fetcher script to search by issue author instead of author and commenter.
- Simplified the issues response processing by removing redundant URL-deduplication logic since author-only results are unique.
- Updated the root gitignore to exclude standard Python cache and build artifacts.

### Verification
- [x] Ran python3 -m py_compile scripts/fetch_contributions.py to verify script syntax correctness.
- [x] Run python3 scripts/fetch_contributions.py locally with GITHUB_TOKEN set to verify correct JSON generation in projects.yaml.

