### PR TITLE
feat(e2e): expand integration test coverage for build pipeline

### DIFF
--- a/e2e/features/draft_filtering.feature
+++ b/e2e/features/draft_filtering.feature
@@ -3,12 +3,14 @@ Feature: Draft Post Filtering
   I want draft posts to be skipped during site generation
   So that unpublished posts do not appear on the live site
 
-  Scenario: Exclude draft posts from build outputs
+  Scenario: Exclude draft posts from build outputs and sitemap
     Given a configuration directory with a valid profile
     And a blog directory containing 1 published post and 1 draft post
     When the build pipeline is executed
     Then the output directory should contain "blog/published-1.html"
     And the output directory should not contain "blog/draft-1.html"
+    And the output file "sitemap.xml" should contain "blog/published-1.html"
+    And the output file "sitemap.xml" should not contain "blog/draft-1.html"
 
   Scenario: Exclude draft posts from the generated RSS feed
     Given a configuration directory with a valid profile
@@ -16,3 +18,12 @@ Feature: Draft Post Filtering
     When the build pipeline is executed
     Then the output file "rss.xml" should contain "Published Post 1"
     And the output file "rss.xml" should not contain "Draft Post 1"
+
+  Scenario: Exclude draft posts from search index and manifest registries
+    Given a configuration directory with a valid profile
+    And a blog directory containing 1 published post and 1 draft post
+    When the build pipeline is executed
+    Then the output file "search-index.json" should contain "Published Post 1"
+    And the output file "search-index.json" should not contain "Draft Post 1"
+    And the output file "api/manifest.json" should contain "Published Post 1"
+    And the output file "api/manifest.json" should not contain "Draft Post 1"

--- a/e2e/features/pipeline.feature
+++ b/e2e/features/pipeline.feature
@@ -8,7 +8,23 @@ Feature: Site Generation Pipeline
     And a blog directory containing 1 published post
     When the build pipeline is executed
     Then the output directory should contain "index.html"
+    And the output directory should contain "about.html"
+    And the output directory should contain "blog.html"
+    And the output directory should contain "404.html"
+    And the output directory should contain "sitemap.xml"
+    And the output directory should contain "rss.xml"
+    And the output directory should contain "search-index.json"
+    And the output directory should contain "llms.txt"
     And the output directory should contain "api/manifest.json"
+    And the output directory should contain "blog"
+    And the output directory should contain "tags"
+
+  Scenario: Copy static assets successfully
+    Given a configuration directory with a valid profile
+    And a static assets directory containing a file "robots.txt"
+    And a blog directory containing 1 published post
+    When the build pipeline is executed
+    Then the output directory should contain "robots.txt"
 
   Scenario: Build fails when configuration is missing
     Given a configuration directory with a missing profile

--- a/e2e/godog_test.go
+++ b/e2e/godog_test.go
@@ -68,6 +68,7 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^a configuration directory with a missing profile$`, tc.setupMissingConfig)
 	sc.Step(`^a blog directory containing (\d+) published post$`, tc.setupSinglePost)
 	sc.Step(`^a blog directory containing (\d+) published post and (\d+) draft post$`, tc.setupMixedPosts)
+	sc.Step(`^a static assets directory containing a file "([^"]*)"$`, tc.setupStaticAsset)
 	sc.Step(`^the build pipeline is executed$`, tc.runPipeline)
 	sc.Step(`^the output directory should contain "([^"]*)"$`, tc.checkFileExists)
 	sc.Step(`^the output directory should not contain "([^"]*)"$`, tc.checkFileMissing)
@@ -143,6 +144,19 @@ func (tc *testContext) setupMissingConfig() error {
 		if err := os.WriteFile(filepath.Join(tc.configDir, file), []byte(content), 0644); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// setupStaticAsset creates a static directory and writes a dummy asset file into it.
+func (tc *testContext) setupStaticAsset(filename string) error {
+	tc.publicDir = filepath.Join(tc.tmpDir, "static")
+	if err := os.MkdirAll(tc.publicDir, 0755); err != nil {
+		return err
+	}
+	content := "User-agent: *\nDisallow: /"
+	if err := os.WriteFile(filepath.Join(tc.publicDir, filename), []byte(content), 0644); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/templates/contents/config.yaml
+++ b/internal/templates/contents/config.yaml
@@ -4,12 +4,12 @@ landing:
   name: Victoria Cheng
   slogan: Backend systems, infrastructure, and the "why" behind them in practice.
   status: "CNCF LFX Mentee · SAIT '26"
-  experience: Shopify · Former Packaging Engineer (4 years)
+  experience: "Prev. Software Engineering Intern at Shopify & Packaging Development Engineer"
   focusAreas:
     - Backend Development
-    - Platform Engineering
     - DevOps
-    - Observability
+    - Platform Engineering
+    - Site Reliability Engineering (SRE)
 
 navigation:
   header:


### PR DESCRIPTION
### Summary
Expands E2E integration test coverage for the static site generator and refines profile metadata. Adds assertions to verify all critical build artifacts (including sitemap, RSS feed, search index, LLM text, and the blog and tags output directories) are generated and draft filtering is applied.

### List of Changes
- Extended pipeline.feature scenarios to check for the presence of all generated files and folders, including blog, tags, and 404.html.
- Updated draft_filtering.feature to assert that draft posts are excluded from sitemap.xml, search-index.json, and api/manifest.json.
- Implemented setupStaticAsset step to verify static asset directory copying during the build pipeline.


### Verification
- [x] Run make test-bdd to execute the expanded Cucumber/Godog E2E integration test suite (6 scenarios, 41 steps passed).
- [x] Run make format && make vet to ensure code formatting and static analysis are correct.
- [x] Run make build to verify the site generation builds successfully with the updated config.yaml.

