### PR TITLE
feat(dev): add Podman dev container with air hot reload

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,19 @@
+root    = "."
+tmp_dir = ".air-tmp"
+
+[build]
+  cmd = "go build -o .air-tmp/server ./cmd/server"
+  bin = ".air-tmp/server"
+
+  include_ext = ["go", "html", "md", "css", "yaml", "yml", "toml"]
+  include_dir = ["cmd", "internal", "blog"]
+  exclude_dir = ["dist", ".git", ".air-tmp"]
+
+  kill_delay = "200ms"
+  delay      = 500
+
+[log]
+  time = true
+
+[misc]
+  clean_on_exit = true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Exclude generated output and toolchain downloads from build context
+dist/
+go-dist/
+tailwindcss
+.air-tmp/
+
+# VCS
+.git/
+.github/
+
+# Editor artifacts
+.vscode/
+.idea/
+
+# Test artifacts
+coverage.out
+coverage.*
+*.coverprofile
+
+# Python
+__pycache__/
+*.py[codz]
+.venv/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,41 @@
+# Usage:
+#   make dev-build   # Build the image
+#   make dev-run     # Start the hot-reload watcher with repo mounted
+#   make dev-clean   # Remove the image
+
+# =============================================================================
+# STAGE 1: tools
+# Builds and downloads all binaries. Nothing from this stage leaks into dev.
+# =============================================================================
+FROM golang:1.26-alpine AS tools
+
+RUN apk add --no-cache curl
+
+RUN go install github.com/air-verse/air@latest && \
+    go install golang.org/x/tools/cmd/goimports@latest
+
+RUN curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 \
+    -o /usr/local/bin/tailwindcss && chmod +x /usr/local/bin/tailwindcss
+
+# =============================================================================
+# STAGE 2: dev
+# Lean runtime. Copies binaries from tools, adds only what air needs to run
+# make targets and shell scripts.
+# =============================================================================
+FROM golang:1.26-alpine AS dev
+
+# make + bash: required to run Makefile targets inside air's build cmd
+# gcompat + libgcc + libstdc++: runtime deps for the Tailwind v4 Bun binary on Alpine/musl
+RUN apk add --no-cache make bash gcompat libgcc libstdc++
+
+COPY --from=tools /go/bin/air                /usr/local/bin/air
+COPY --from=tools /go/bin/goimports          /usr/local/bin/goimports
+COPY --from=tools /usr/local/bin/tailwindcss /usr/local/bin/tailwindcss
+
+WORKDIR /workspace
+COPY go.mod go.sum ./
+RUN go mod download
+
+EXPOSE 8080
+
+CMD ["air"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 include mk/go.mk
 include mk/tailwind.mk
 include mk/markdown.mk
+include mk/docker.mk
 
 .PHONY: help test-all
 
@@ -34,6 +35,11 @@ help:
 	@echo "  setup-tailwind  Download Tailwind CLI (Linux x64)"
 	@echo "  setup-go        Download and setup Go locally"
 	@echo "  ssg-build       Setup Go and Tailwind, then build the SSG"
+	@echo ""
+	@echo "Local Dev (Podman):"
+	@echo "  dev-build       Build the dev container image"
+	@echo "  dev-run         Start an interactive shell with repo mounted"
+	@echo "  dev-clean       Remove the dev container image"
 	@echo ""
 	@echo "Utility:"
 	@echo "  help            Show this help message"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"mehub/internal"
+)
+
+const port = ":8080"
+
+// buildID is set once at startup. Because air restarts the process on every
+// rebuild, each new server has a different ID. The browser detects the change
+// and reloads.
+var buildID = strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+// liveReloadSnippet is injected before </body> in every HTML response.
+// It polls /dev-reload every second and reloads when the build ID changes.
+const liveReloadSnippet = `<script>
+(function() {
+	var id = null;
+	setInterval(function() {
+		fetch('/dev-reload')
+			.then(function(r) { return r.text(); })
+			.then(function(v) {
+				if (id === null) { id = v; return; }
+				if (v !== id) { location.reload(); }
+			})
+			.catch(function() {});
+	}, 1000);
+})();
+</script>`
+
+func main() {
+	if err := build(); err != nil {
+		log.Fatalf("initial build failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/dev-reload", devReloadHandler)
+	mux.HandleFunc("/", serveHandler)
+
+	log.Printf("dev server → http://localhost%s", port)
+	if err := http.ListenAndServe(port, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// devReloadHandler returns the current build ID as plain text.
+// The browser compares successive responses and reloads on change.
+func devReloadHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Cache-Control", "no-cache")
+	fmt.Fprint(w, buildID)
+}
+
+// serveHandler serves files from dist/. HTML files have the live-reload script
+// injected before </body>. All other files are served directly.
+func serveHandler(w http.ResponseWriter, r *http.Request) {
+	p := filepath.Join("dist", filepath.Clean(r.URL.Path))
+
+	info, err := os.Stat(p)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	if info.IsDir() {
+		p = filepath.Join(p, "index.html")
+	}
+
+	if strings.HasSuffix(p, ".html") {
+		serveHTML(w, r, p)
+		return
+	}
+
+	http.ServeFile(w, r, p)
+}
+
+// serveHTML reads an HTML file, injects the live-reload script, and writes it.
+func serveHTML(w http.ResponseWriter, r *http.Request, path string) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	body := strings.Replace(string(content), "</body>", liveReloadSnippet+"</body>", 1)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, body)
+}
+
+// build runs the SSG pipeline then compiles Tailwind CSS.
+func build() error {
+	start := time.Now()
+
+	count, err := internal.RunPipeline(
+		"dist",
+		"internal/templates/contents",
+		"internal/templates",
+		"blog",
+		"internal/templates/static",
+	)
+	if err != nil {
+		return fmt.Errorf("ssg pipeline: %w", err)
+	}
+
+	if err := runTailwind(); err != nil {
+		return fmt.Errorf("tailwind: %w", err)
+	}
+
+	log.Printf("✅ built %d posts in %v", count, time.Since(start))
+	return nil
+}
+
+// runTailwind compiles input.css into dist/styles.css.
+func runTailwind() error {
+	cmd := exec.Command(
+		"tailwindcss",
+		"-i", "internal/templates/input.css",
+		"-o", "dist/styles.css",
+		"--minify",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w\n%s", err, out)
+	}
+	return nil
+}

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -1,0 +1,22 @@
+DEV_IMAGE=mehub-dev
+DEV_CONTAINER=mehub-dev
+
+.PHONY: dev-build dev-run dev-clean
+
+## dev-build: Build the local development container image.
+dev-build:
+	podman build -f Dockerfile.dev -t $(DEV_IMAGE) .
+
+## dev-run: Run an interactive shell inside the dev container with the repo mounted.
+dev-run:
+	podman run --rm -it \
+		-v "$(PWD)":/workspace:Z \
+		-w /workspace \
+		-p 8080:8080 \
+		--name $(DEV_CONTAINER) \
+		$(DEV_IMAGE)
+
+## dev-clean: Remove the local development container image.
+dev-clean:
+	podman rmi --force $(DEV_IMAGE)
+	@echo "Image '$(DEV_IMAGE)' removed."


### PR DESCRIPTION
### Summary
Adds a containerized local development environment using Podman, enabling
reproducible builds without requiring host-level Go or Node tooling. A
multi-stage Alpine Dockerfile, air-based hot reload, and a lightweight Go
dev server replace the previous manual workflow of running `make build`
directly on the host.

### List of Changes
- Introduces `Dockerfile.dev` (multi-stage Alpine build) with air, goimports,
  and the Tailwind v4 CLI baked in, plus `mk/docker.mk` exposing `dev-build`,
  `dev-run`, and `dev-clean` targets so the full dev loop is a single command.
- Adds `cmd/server/main.go`, a dev-only HTTP server that runs the SSG pipeline
  and Tailwind on startup, serves `dist/` on `:8080`, and injects a polling
  script into HTML pages so the browser detects rebuilds automatically.

### Verification
- [x] `make dev-build` completes without error
- [x] `make dev-run` starts the server and site is reachable at http://localhost:8080
- [x] Editing a file in `internal/`, `cmd/`, or `blog/` triggers a rebuild in the container logs
- [x] `make vet` passes

