### PR TITLE
fix(workflow): use PAT and unique branch name for contributions

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -10,7 +10,6 @@ permissions:
   pull-requests: write
 
 env:
-  BRANCH_NAME: automation/update-contributions
   PYTHON_VERSION: '3.12'
   PROJECTS_YAML_PATH: internal/templates/contents/projects.yaml
   UPDATE_MESSAGE: 'chore(contribution): update open source contributions'
@@ -27,9 +26,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Set branch name
+        run: echo "BRANCH_NAME=chore/update-contributions-$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Fetch latest contributions
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SYNC_BLOG_TOKEN }}
         run: python3 scripts/fetch_contributions.py
 
       - name: Check for changes


### PR DESCRIPTION
### Summary
The `update-contributions` workflow was using the built-in `GITHUB_TOKEN`,
which is scoped to the current repository and cannot reliably search for
pull requests across external organizations. Switching to `SYNC_BLOG_TOKEN`
(a PAT with `public_repo` scope) and appending a Unix timestamp to the
branch name ensures each run creates a unique branch.

### List of Changes
- Replaces `GITHUB_TOKEN` with `SYNC_BLOG_TOKEN` for the fetch step so
  cross-repo PR and issue search returns complete results from external orgs.
- Generates a unique branch name per run by appending `$(date +%s)`, preventing
  branch collisions between scheduled and manually triggered executions.

