### PR TITLE
feat(blog): add tag audit script and clean up blog post tags

### DIFF
--- a/blog/building-a-gitops-homelab-platform-pipeline.md
+++ b/blog/building-a-gitops-homelab-platform-pipeline.md
@@ -2,7 +2,7 @@
 title: "Building a GitOps Homelab Platform Pipeline"
 description: "Manual pod updates became a GitOps platform pipeline where CI builds images, Kustomize separates dev and prod, ArgoCD reconciles drift, and short-SHA tags trace rollbacks."
 date: 2026-05-12
-tags: ["kubernetes", "platform"]
+tags: ["docker", "kubernetes", "platform"]
 ---
 ## From Sideloading to a Platform Pipeline
 

--- a/blog/docker-compose-configuring-images-and-container-names.md
+++ b/blog/docker-compose-configuring-images-and-container-names.md
@@ -2,7 +2,7 @@
 title: "Docker Compose - Configuring Images and Container Names"
 description: "Enhance Docker deployment with custom names for organized images and containers. Explore efficient file transfers using the 'docker cp' command. Dive into the full post."
 date: 2024-02-01
-tags: ["platform"]
+tags: ["docker", "platform"]
 ---
 
 

--- a/blog/engineering-log-the-phased-migration-to-kubernetes.md
+++ b/blog/engineering-log-the-phased-migration-to-kubernetes.md
@@ -2,7 +2,7 @@
 title: "[Engineering Log] The Phased Migration to Kubernetes"
 description: "Executing a risk-based, four-stage migration of the observability stack from Docker to Kubernetes to ensure data integrity and system stability."
 date: 2026-03-17
-tags: ["kubernetes", "observability", "retrospective"]
+tags: ["docker", "kubernetes", "retrospective"]
 ---
 
 ## Context

--- a/blog/scaling-with-systemd-template-units.md
+++ b/blog/scaling-with-systemd-template-units.md
@@ -2,7 +2,7 @@
 title: "Scaling with Systemd Template Units"
 description: "Learn to scale Linux automation using Systemd Template Units. Discover how the '@' symbol and gitops-sync timers simplify service management. Read the full guide to learn."
 date: 2026-02-10
-tags: ["linux", "retrospective"]
+tags: ["linux", "platform"]
 ---
 
 ## The Discovery: Deciphering the '@' Symbol

--- a/blog/single-stage-or-multi-stage-docker-builds.md
+++ b/blog/single-stage-or-multi-stage-docker-builds.md
@@ -2,7 +2,7 @@
 title: "Single-Stage or Multi-Stage Docker Builds"
 description: "Explore single-stage vs multi-stage Docker builds with a small Flask API, learning differences in image size, build speed, and container optimization. Read more to learn."
 date: 2025-11-11
-tags: ["platform"]
+tags: ["docker", "platform"]
 ---
 
 ## What is Single-Stage or Multi-Stage Docker Builds?

--- a/blog/systemic-reliability-sli-vs-slo-patterns.md
+++ b/blog/systemic-reliability-sli-vs-slo-patterns.md
@@ -2,7 +2,7 @@
 title: "Systemic Reliability: SLI vs SLO Patterns"
 description: "An objective analysis of Service Level Indicators and Objectives, detailing the architectural transition from raw metrics to business-aligned reliability targets for scale."
 date: 2026-06-02
-tags: ["observability", "platform", "system-design"]
+tags: ["observability", "sre", "system-design"]
 ---
 
 ## The Operational Bottleneck of Subjectivity

--- a/blog/the-sre-era-standardizing-opentelemetry.md
+++ b/blog/the-sre-era-standardizing-opentelemetry.md
@@ -2,7 +2,7 @@
 title: "The SRE Era: Standardizing OpenTelemetry"
 description: "Mastering SRE principles by transitioning from ad-hoc data collection to a standardized OpenTelemetry ecosystem using Prometheus, Grafana Tempo, and MinIO for persistence."
 date: 2026-03-24
-tags: ["cloud", "kubernetes", "observability"]
+tags: ["kubernetes", "observability", "sre"]
 ---
 
 ## The Shift: From "Working" to "Standardized"

--- a/blog/trying-azure-container-registry.md
+++ b/blog/trying-azure-container-registry.md
@@ -2,7 +2,7 @@
 title: "Trying Azure Container Registry"
 description: "Learn how I used Azure Container Registry to securely store Docker images from a personal project, with GitHub Actions CI and zero hardcoded secrets. Read more to learn."
 date: 2025-12-16
-tags: ["cloud", "platform"]
+tags: ["cloud", "docker", "platform"]
 ---
 
 ## What is Azure Container Registry?

--- a/scripts/audit_tags.py
+++ b/scripts/audit_tags.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Audit blog post tags.
+
+- Prints all unique tags across the blog directory.
+- Validates that every engineering log post carries the 'retrospective' tag.
+- Validates that no non-engineering-log post carries the 'retrospective' tag.
+- Validates that no post exceeds MAX_TAGS tags.
+- Validates that all tags belong to the known tag list.
+- Exits with code 1 if any violations are found.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+BLOG_DIR = os.path.join(os.path.dirname(__file__), "..", "blog")
+ENGINEERING_LOG_PREFIX = "engineering-log-"
+REQUIRED_TAG = "retrospective"
+MAX_TAGS = 3
+
+KNOWN_TAGS = {
+    "backend",
+    "cloud",
+    "cncf",
+    "data-structure",
+    "docker",
+    "frontend",
+    "go",
+    "growth",
+    "javascript",
+    "kubernetes",
+    "linux",
+    "mcp",
+    "monthly-log",
+    "observability",
+    "platform",
+    "python",
+    "retrospective",
+    "sre",
+    "system-design",
+    "terraform",
+    "typescript",
+}
+
+TAG_PATTERN = re.compile(r'^tags:\s*\[([^\]]+)\]', re.MULTILINE)
+SINGLE_TAG = re.compile(r'"([^"]+)"')
+
+
+def parse_tags(content: str) -> list[str]:
+    match = TAG_PATTERN.search(content)
+    if not match:
+        return []
+    return SINGLE_TAG.findall(match.group(1))
+
+
+def run_checks(filename: str, tags: list[str]) -> list[str]:
+    """Return a list of violation strings for a single post."""
+    issues = []
+
+    # Engineering log must carry retrospective; others must not.
+    if filename.startswith(ENGINEERING_LOG_PREFIX):
+        if REQUIRED_TAG not in tags:
+            issues.append(f"missing '{REQUIRED_TAG}' tag")
+    else:
+        if REQUIRED_TAG in tags:
+            issues.append(f"carries '{REQUIRED_TAG}' but is not an engineering log")
+
+    # Tag count ceiling.
+    if len(tags) > MAX_TAGS:
+        issues.append(f"exceeds {MAX_TAGS} tags ({len(tags)} found: {tags})")
+
+    # Unknown tags.
+    unknown = sorted(set(tags) - KNOWN_TAGS)
+    if unknown:
+        issues.append(f"unknown tag(s): {unknown}")
+
+    return issues
+
+
+def main() -> int:
+    all_tags: set[str] = set()
+    violations: dict[str, list[str]] = {}
+
+    posts = sorted(f for f in os.listdir(BLOG_DIR) if f.endswith(".md"))
+
+    for filename in posts:
+        path = os.path.join(BLOG_DIR, filename)
+        with open(path, encoding="utf-8") as fh:
+            content = fh.read()
+
+        tags = parse_tags(content)
+        all_tags.update(tags)
+
+        issues = run_checks(filename, tags)
+        if issues:
+            violations[filename] = issues
+
+    print("=== All tags ===")
+    print(sorted(all_tags))
+    print(f"\nTotal unique tags: {len(all_tags)}")
+
+    checks = [
+        f"engineering log posts carry '{REQUIRED_TAG}'",
+        f"no non-engineering-log posts carry '{REQUIRED_TAG}'",
+        f"no post exceeds {MAX_TAGS} tags",
+        "all tags are known",
+    ]
+
+    print("\n=== Tag audit ===")
+    if violations:
+        print(f"FAIL — {len(violations)} post(s) with violations:\n")
+        for filename, issues in violations.items():
+            print(f"  {filename}")
+            for issue in issues:
+                print(f"    - {issue}")
+        return 1
+
+    for check in checks:
+        print(f"OK — {check}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Summary
Adds a tag validation script to automate frontmatter audits across the blog. Cleans up existing post frontmatter to align with the new tags and ensures every post adheres to a maximum ceiling of three tags.

### List of Changes
- Adds `scripts/audit_tags.py` to check tag counts, validate against a list of known tags, and enforce engineering log tag rules.
- Updates frontmatter tags across modified blog posts to resolve miscategorized retrospective tags and prune lists down to three tags.

### Verification
- [x] Run `python3 scripts/audit_tags.py` locally and verify it exits with 0 and prints the clean audit status.
- [x] Run `make build` to verify the static site generator compiles all updated post frontmatter without warnings.

