### PR TITLE
feat(contribution): add lastUpdated property to contributions

### DIFF
--- a/e2e/features/pipeline.feature
+++ b/e2e/features/pipeline.feature
@@ -30,3 +30,10 @@ Feature: Site Generation Pipeline
     Given a configuration directory with a missing profile
     When the build pipeline is executed
     Then the build pipeline execution should fail
+
+  Scenario: Render open source contributions on the home page
+    Given a configuration directory with a valid profile containing contributions
+    When the build pipeline is executed
+    Then the output file "index.html" should contain "Open Source Contributions"
+    And the output file "index.html" should contain "Last updated: 2026-07-18"
+    And the output file "index.html" should contain "test-repo"

--- a/e2e/godog_test.go
+++ b/e2e/godog_test.go
@@ -65,6 +65,7 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	})
 
 	sc.Step(`^a configuration directory with a valid profile$`, tc.setupValidConfig)
+	sc.Step(`^a configuration directory with a valid profile containing contributions$`, tc.setupValidConfigWithContributions)
 	sc.Step(`^a configuration directory with a missing profile$`, tc.setupMissingConfig)
 	sc.Step(`^a blog directory containing (\d+) published post$`, tc.setupSinglePost)
 	sc.Step(`^a blog directory containing (\d+) published post and (\d+) draft post$`, tc.setupMixedPosts)
@@ -129,6 +130,46 @@ socials: []
 	}
 
 	return nil
+}
+
+// setupValidConfigWithContributions creates a valid profile environment loaded with open source contributions.
+func (tc *testContext) setupValidConfigWithContributions() error {
+	if err := tc.setupValidConfig(); err != nil {
+		return err
+	}
+	if err := tc.setupSinglePost(1); err != nil {
+		return err
+	}
+	projectsYAML := `projects: []
+contributions:
+  lastUpdated: "2026-07-18"
+  items:
+    - repo: "test-repo"
+      link: "https://github.com/test-repo"
+      description: "Test description"
+      items:
+        - type: "PR"
+          number: 123
+          title: "Test PR"
+          status: "merged"
+`
+	if err := os.WriteFile(filepath.Join(tc.configDir, "projects.yaml"), []byte(projectsYAML), 0644); err != nil {
+		return err
+	}
+
+	indexHTML := `{{ define "content" }}
+	<h1>{{ .Title }}</h1>
+	{{ if .Config.Contributions.Items }}
+		<h2>Open Source Contributions</h2>
+		<span>Last updated: {{ .Config.Contributions.LastUpdated }}</span>
+		<ul>
+			{{ range .Config.Contributions.Items }}
+				<li>{{ .Repo }}</li>
+			{{ end }}
+		</ul>
+	{{ end }}
+	{{ end }}`
+	return os.WriteFile(filepath.Join(tc.templatesDir, "index.html"), []byte(indexHTML), 0644)
 }
 
 // setupMissingConfig creates a contents directory with navigation/metadata but missing the critical profile.yaml.

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -53,6 +53,12 @@ type Contribution struct {
 	Items       []ContributionItem `yaml:"items"`
 }
 
+// ContributionsSection represents the contributions block containing the last updated timestamp and the list of contribution items.
+type ContributionsSection struct {
+	LastUpdated string         `yaml:"lastUpdated"`
+	Items       []Contribution `yaml:"items"`
+}
+
 // Skill represents a technology tag paired with a matching display icon or CSS utility.
 type Skill struct {
 	Name string `yaml:"name"`
@@ -80,13 +86,13 @@ type LandingConfig struct {
 
 // SiteConfig represents the full composite profile parsed from YAML configurations in the repository.
 type SiteConfig struct {
-	Landing       LandingConfig    `yaml:"landing"`
-	Navigation    NavigationConfig `yaml:"navigation"`
-	About         AboutConfig      `yaml:"about"`
-	Socials       []Social         `yaml:"socials"`
-	Projects      []Project        `yaml:"projects"`
-	Skills        []Skill          `yaml:"skills"`
-	Contributions []Contribution   `yaml:"contributions"`
+	Landing       LandingConfig        `yaml:"landing"`
+	Navigation    NavigationConfig     `yaml:"navigation"`
+	About         AboutConfig          `yaml:"about"`
+	Socials       []Social             `yaml:"socials"`
+	Projects      []Project            `yaml:"projects"`
+	Skills        []Skill              `yaml:"skills"`
+	Contributions ContributionsSection `yaml:"contributions"`
 }
 
 // ============================================================================

--- a/internal/templates/contents/projects.yaml
+++ b/internal/templates/contents/projects.yaml
@@ -55,43 +55,45 @@ projects:
       - eBPF
 
 contributions:
-  - repo: chaos-mesh/chaos-mesh
-    link: https://github.com/chaos-mesh/chaos-mesh
-    description: "A Chaos Engineering Platform for Kubernetes."
-    items:
-      - type: PR
-        number: 5034
-        title: "fix(dashboard): fix TypeError crash on Workflow schedule details"
-        status: open
-      - type: PR
-        number: 5028
-        title: "refactor(e2e-test): integrate gherkin in CI and migrate namespace setup"
-        status: open
-      - type: PR
-        number: 5016
-        title: "fix(dashboard): support serving UI under a configurable subpath"
-        status: merged
-      - type: PR
-        number: 5013
-        title: "feat(e2e-test): implement gherkin BDD runner and podkill scenarios"
-        status: merged
-      - type: Issue
-        number: 5031
-        title: "[Bug]: TypeError: Cannot read properties of undefined (reading 'selector')"
-        status: open
-  - repo: cncf/open-community-groups
-    link: https://github.com/cncf/open-community-groups
-    description: "Open source events platform for communities and organizations"
-    items:
-      - type: Issue
-        number: 582
-        title: "Display event times in logged-in user's preferred timezone"
-        status: open
-  - repo: cucumber/godog
-    link: https://github.com/cucumber/godog
-    description: "Cucumber for golang"
-    items:
-      - type: PR
-        number: 760
-        title: "fix(hooks): wrap errors to preserve sentinel values"
-        status: open
+  lastUpdated: "2026-07-18"
+  items:
+    - repo: chaos-mesh/chaos-mesh
+      link: https://github.com/chaos-mesh/chaos-mesh
+      description: "A Chaos Engineering Platform for Kubernetes."
+      items:
+        - type: PR
+          number: 5034
+          title: "fix(dashboard): fix TypeError crash on Workflow schedule details"
+          status: open
+        - type: PR
+          number: 5028
+          title: "refactor(e2e-test): integrate gherkin in CI and migrate namespace setup"
+          status: open
+        - type: PR
+          number: 5016
+          title: "fix(dashboard): support serving UI under a configurable subpath"
+          status: merged
+        - type: PR
+          number: 5013
+          title: "feat(e2e-test): implement gherkin BDD runner and podkill scenarios"
+          status: merged
+        - type: Issue
+          number: 5031
+          title: "[Bug]: TypeError: Cannot read properties of undefined (reading 'selector')"
+          status: open
+    - repo: cncf/open-community-groups
+      link: https://github.com/cncf/open-community-groups
+      description: "Open source events platform for communities and organizations"
+      items:
+        - type: Issue
+          number: 582
+          title: "Display event times in logged-in user's preferred timezone"
+          status: open
+    - repo: cucumber/godog
+      link: https://github.com/cucumber/godog
+      description: "Cucumber for golang"
+      items:
+        - type: PR
+          number: 760
+          title: "fix(hooks): wrap errors to preserve sentinel values"
+          status: open

--- a/internal/templates/index.html
+++ b/internal/templates/index.html
@@ -30,7 +30,7 @@
     </section>
 
     <section class="flex flex-col gap-6">
-        <h2 class="text-sm font-bold text-violet-400 tracking-wider uppercase">Tech Stack</h2>
+        <h2 class="font-bold text-violet-400 tracking-wider uppercase">Tech Stack</h2>
         <ul class="flex flex-wrap gap-3 list-none ">
             {{ range .Config.Skills }}
             <li class="flex items-center gap-3 px-4 py-2 bg-slate-900 border border-slate-800 rounded-lg hover:border-violet-500/30 transition-colors group">
@@ -42,11 +42,14 @@
         </ul>
     </section>
 
-    {{ if .Config.Contributions }}
+    {{ if .Config.Contributions.Items }}
     <section class="flex flex-col gap-6">
-        <h2 class="text-sm font-bold text-violet-400 tracking-wider uppercase">Open Source Contributions</h2>
+        <div class="flex flex-col gap-1">
+            <span class="text-xs text-slate-500 font-normal uppercase tracking-wider">Last updated: {{ .Config.Contributions.LastUpdated }}</span>
+            <h2 class="font-bold text-violet-400 tracking-wider uppercase">Open Source Contributions</h2>
+        </div>
         <ul class="flex flex-col gap-6 list-none">
-            {{ range $cIndex, $contrib := .Config.Contributions }}
+            {{ range $cIndex, $contrib := .Config.Contributions.Items }}
             <li>
                 <article class="flex flex-col gap-4 p-6 bg-slate-900 border border-slate-800 rounded-xl">
                     <div class="flex flex-col gap-2">
@@ -120,7 +123,7 @@
     {{ end }}
 
     <section class="flex flex-col gap-6">
-        <h2 class="text-sm font-bold text-violet-400 tracking-wider uppercase">Featured Projects</h2>
+        <h2 class="font-bold text-violet-400 tracking-wider uppercase">Featured Projects</h2>
         <ul class="flex flex-col gap-6 list-none">
             {{ range $index, $project := .Config.Projects }}
             <li class="{{ if ge $index 4 }}hidden additional-project transition-all duration-300{{ end }} h-full">

--- a/scripts/fetch_contributions.py
+++ b/scripts/fetch_contributions.py
@@ -9,6 +9,7 @@ Uses only the Python standard library (no pip dependencies required).
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import sys
@@ -185,19 +186,24 @@ def escape_yaml_string(s: str) -> str:
 
 def generate_contributions_yaml(contributions: list[dict]) -> str:
     """Convert contributions list to formatted YAML string."""
-    yaml_lines = ["contributions:"]
+    current_date = datetime.date.today().isoformat()
+    yaml_lines = [
+        "contributions:",
+        f"  lastUpdated: \"{current_date}\"",
+        "  items:"
+    ]
     for contrib in contributions:
-        yaml_lines.append(f"  - repo: {contrib['repo']}")
-        yaml_lines.append(f"    link: {contrib['link']}")
+        yaml_lines.append(f"    - repo: {contrib['repo']}")
+        yaml_lines.append(f"      link: {contrib['link']}")
         escaped_desc = escape_yaml_string(contrib['description'])
-        yaml_lines.append(f"    description: \"{escaped_desc}\"")
-        yaml_lines.append("    items:")
+        yaml_lines.append(f"      description: \"{escaped_desc}\"")
+        yaml_lines.append("      items:")
         for item in contrib["items"]:
-            yaml_lines.append(f"      - type: {item['type']}")
-            yaml_lines.append(f"        number: {item['number']}")
+            yaml_lines.append(f"        - type: {item['type']}")
+            yaml_lines.append(f"          number: {item['number']}")
             escaped_title = escape_yaml_string(item['title'])
-            yaml_lines.append(f"        title: \"{escaped_title}\"")
-            yaml_lines.append(f"        status: {item['status']}")
+            yaml_lines.append(f"          title: \"{escaped_title}\"")
+            yaml_lines.append(f"          status: {item['status']}")
     return "\n".join(yaml_lines) + "\n"
 
 


### PR DESCRIPTION
### Summary
The personal website contributions section lacked a transparent timestamp to indicate when it was last refreshed by the automated ingestion pipeline. This change updates the configuration schemas and index templates to render an overall `lastUpdated` date for external contributions. It also automates date calculation within the fetch script, ensuring transparent updates without manual overhead.

### List of Changes
- Provide visibility and transparency into the freshness of external open source contributions on the home page.
- Automate timestamp recording during GitHub ingestion runs to eliminate manual maintenance and prevent stale configuration entries.
- Simplify template layout by removing conditional date checks and clean up heading sizes on the landing page for visual consistency.

### Verification
- [x] `make test-all`
- [x] `make format && make vet`
- [x] `python3 -m py_compile scripts/fetch_contributions.py`

