### PR TITLE
chore(workflows): update contributions workflow schedule and command

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -2,7 +2,7 @@ name: Update Contributions
 
 on:
   schedule:
-    - cron: '30 0 * * 2,6'
+    - cron: '30 0 * * 1,5'
   workflow_dispatch:
 
 permissions:
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git checkout -B "$BRANCH_NAME"
+          git switch -c "$BRANCH_NAME"
           git add "$PROJECTS_YAML_PATH"
           git commit -m "$UPDATE_MESSAGE"
           git push --force-with-lease origin "$BRANCH_NAME"


### PR DESCRIPTION
### Summary
This change reschedules the automated open source contributions update workflow to run on Mondays and Fridays instead of Tuesdays and Saturdays. Rescheduling prevents conflicts with the Tuesday blog publication workflow and stabilizes the integration process. Additionally, the workflow steps are updated to use the modern, intent-specific `git switch -c` command rather than `git checkout -B`.

### List of Changes
- Adjust the contributions update workflow schedule to run on Mondays and Fridays, avoiding concurrent run conflicts with the Tuesday blog publishing pipeline.
- Modernize branch creation in the GitHub Actions workflow by replacing the legacy checkout command with switch commands.

### Verification
- [x] Manually inspect the cron expression `30 0 * * 1,5`.

