### PR TITLE
refactor(scripts): decouple fork parent resolution using local cache

### DIFF
--- a/scripts/fetch_contributions.py
+++ b/scripts/fetch_contributions.py
@@ -20,7 +20,7 @@ import urllib.request
 # Configuration settings
 USERNAME = os.environ.get("GITHUB_USER", "victoriacheng15")
 API_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-REPOS = ["chaos-mesh/chaos-mesh",  "cncf/open-community-groups", "meshery/meshery", "cucumber/godog"]
+REPOS: list[str] = []
 
 # API base headers (preserving custom User-Agent)
 HEADERS = {
@@ -34,6 +34,7 @@ if API_TOKEN:
 # File location configurations
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECTS_YAML_PATH = os.path.join(SCRIPT_DIR, "..", "internal", "templates", "contents", "projects.yaml")
+CACHE_PATH = os.path.join(SCRIPT_DIR, "fork_cache.json")
 
 
 def query_github_api(url: str) -> dict:
@@ -47,6 +48,24 @@ def query_github_api(url: str) -> dict:
         raise SystemExit(f"GitHub API HTTP Error [{err.code}]: {error_details}")
     except urllib.error.URLError as err:
         raise SystemExit(f"GitHub API Network Connection Error: {err.reason}")
+
+
+def load_fork_parents() -> list[str]:
+    """Load parent repository names from scripts/fork_cache.json."""
+    if not os.path.exists(CACHE_PATH):
+        print(f"Error: {CACHE_PATH} not found. Please run scripts/update_fork_cache.py first.", file=sys.stderr)
+        sys.exit(1)
+        
+    try:
+        with open(CACHE_PATH, "r", encoding="utf-8") as f:
+            cache = json.load(f)
+        if isinstance(cache, dict):
+            return list(cache.values())
+    except Exception as err:
+        print(f"Error loading cache from {CACHE_PATH}: {err}", file=sys.stderr)
+        sys.exit(1)
+        
+    return []
 
 
 def fetch_external_pull_requests() -> list[dict]:
@@ -224,6 +243,10 @@ def fetch_external_issues() -> list[dict]:
 
 
 def main() -> None:
+    global REPOS
+    print("Loading active fork repositories from cache...", file=sys.stderr)
+    REPOS = load_fork_parents()
+
     print("Fetching external contributions from GitHub...", file=sys.stderr)
     raw_prs = fetch_external_pull_requests()
     print("Fetching external issues from GitHub...", file=sys.stderr)
@@ -276,14 +299,8 @@ def main() -> None:
             }
             updated_contributions.append(updated_contrib)
 
-    # Sort all contributions to match the order in REPOS
-    def get_sort_key(contrib: dict) -> tuple[int, str]:
-        repo = contrib["repo"]
-        if REPOS and repo in REPOS:
-            return (REPOS.index(repo), repo)
-        return (len(REPOS) if REPOS else 0, repo)
-
-    updated_contributions.sort(key=get_sort_key)
+    # Sort all contributions alphabetically by repository name to group by organization
+    updated_contributions.sort(key=lambda x: x["repo"].lower())
 
     # Assemble updated projects.yaml
     clean_yaml = strip_existing_contributions(yaml_text)

--- a/scripts/fork_cache.json
+++ b/scripts/fork_cache.json
@@ -1,0 +1,14 @@
+{
+  "victoriacheng15/argo-cd": "argoproj/argo-cd",
+  "victoriacheng15/chaos-mesh": "chaos-mesh/chaos-mesh",
+  "victoriacheng15/contribute-site": "cncf/contribute-site",
+  "victoriacheng15/godog": "cucumber/godog",
+  "victoriacheng15/headlamp": "kubernetes-sigs/headlamp",
+  "victoriacheng15/kepler": "sustainable-computing-io/kepler",
+  "victoriacheng15/kubeedge": "kubeedge/kubeedge",
+  "victoriacheng15/meshery": "meshery/meshery",
+  "victoriacheng15/meshery.io": "meshery/meshery.io",
+  "victoriacheng15/open-community-groups": "cncf/open-community-groups",
+  "victoriacheng15/opentofu": "opentofu/opentofu",
+  "victoriacheng15/website": "chaos-mesh/website"
+}

--- a/scripts/update_fork_cache.py
+++ b/scripts/update_fork_cache.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Update the scripts/fork_cache.json file by querying the GitHub API.
+Resolves active (non-archived) forks owned by the user and finds their upstream parents.
+Uses only the Python standard library.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+USERNAME = os.environ.get("GITHUB_USER", "victoriacheng15")
+API_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": f"update-fork-cache-{USERNAME}",
+}
+if API_TOKEN:
+    HEADERS["Authorization"] = f"Bearer {API_TOKEN}"
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CACHE_PATH = os.path.join(SCRIPT_DIR, "fork_cache.json")
+
+
+def query_github_api(url: str) -> dict:
+    """Send a GET request to the GitHub API and return parsed JSON data."""
+    request = urllib.request.Request(url, headers=HEADERS)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as err:
+        error_details = err.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"GitHub API HTTP Error [{err.code}]: {error_details}")
+    except urllib.error.URLError as err:
+        raise SystemExit(f"GitHub API Network Connection Error: {err.reason}")
+
+
+def main() -> None:
+    print("Fetching active fork repositories from GitHub...", file=sys.stderr)
+    url = f"https://api.github.com/users/{USERNAME}/repos?per_page=100"
+    payload = query_github_api(url)
+    if not isinstance(payload, list):
+        print("Error: Expected a list of repositories from GitHub API.", file=sys.stderr)
+        sys.exit(1)
+
+    cache = {}
+    for repo in payload:
+        if repo.get("fork") and not repo.get("archived"):
+            repo_name = repo["full_name"]
+            print(f"Resolving parent for {repo_name}...", file=sys.stderr)
+            detail_url = f"https://api.github.com/repos/{repo_name}"
+            try:
+                detail = query_github_api(detail_url)
+                parent = detail.get("parent", {}).get("full_name")
+                if parent:
+                    cache[repo_name] = parent
+            except Exception as err:
+                print(f"Warning: Failed to fetch parent for {repo_name}: {err}", file=sys.stderr)
+
+    with open(CACHE_PATH, "w", encoding="utf-8") as f:
+        json.dump(cache, f, indent=2)
+    print(f"Successfully updated cache with {len(cache)} active parents in {CACHE_PATH}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
### Summary
Decouple the repository list resolution from the active contribution fetching script by implementing a local cache mechanism. A new script resolves parent names of active forks weekly to update the cache, while the primary fetching script reads directly from it. This prevents GitHub API rate-limiting issues and speeds up execution.

### List of Changes
- Create update_fork_cache.py to dynamically query active, unarchived user fork parent names once a week and write to fork_cache.json.
- Refactor fetch_contributions.py to load repository targets directly from fork_cache.json and sort them alphabetically by owner/repo to stack organization repositories together.

### Verification
- [x] Run `python3 -m py_compile scripts/update_fork_cache.py scripts/fetch_contributions.py` to verify syntax correctness.
- [x] Run `python3 scripts/update_fork_cache.py` and `python3 scripts/fetch_contributions.py` to confirm successful execution and output.

