### PR TITLE
feat(ui): improve responsive layout and mobile usability of templates

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -54,8 +54,8 @@
 
 </html>
 {{ define "header" }}
-<header class="w-full flex flex-col sm:flex-row justify-between items-center gap-4 pb-6 border-b border-violet-500/20">
-    <div class="flex flex-col items-center sm:items-start">
+<header class="w-full flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 pb-6 border-b border-violet-500/20">
+    <div class="flex flex-col items-start">
         <a href="{{ .PathPrefix }}index.html"
             class="text-2xl font-bold text-violet-400 hover:text-violet-300 transition-colors">
             {{ .Config.Landing.Title }}

--- a/internal/templates/blog.html
+++ b/internal/templates/blog.html
@@ -16,7 +16,7 @@
     </div>
 
     <!-- Topic Filters -->
-    <ul class="flex flex-wrap gap-2 list-none">
+    <ul class="flex flex-wrap gap-3 list-none">
         <li>
             <a href="{{ .PathPrefix }}blog.html" class="px-3 py-1.5 text-xs font-bold rounded-full border transition-all {{ if not (stringsHasPrefix .Title "#") }}bg-violet-500/10 border-violet-500/30 text-violet-400{{ else }}bg-slate-900 border-slate-800 text-slate-400 hover:text-violet-400 hover:border-violet-500/30{{ end }}">
                 All
@@ -48,7 +48,7 @@
                         {{ .Title }}
                     </h2>
                     <p class="text-slate-400 leading-relaxed text-sm">{{ .Description }}</p>
-                    <ul class="flex gap-2 list-none ">
+                    <ul class="flex flex-wrap gap-3 list-none">
                         {{ range .Tags }}
                         <li class="px-2 py-1 bg-slate-800 text-slate-300 text-xs font-semibold rounded border border-slate-700">#{{ . }}</li>
                         {{ end }}
@@ -148,7 +148,7 @@
                             ${item.title}
                         </h2>
                         <p class="text-slate-400 leading-relaxed text-sm">${item.description}</p>
-                        <ul class="flex gap-2 list-none ">
+                        <ul class="flex flex-wrap gap-3 list-none">
                             ${item.tags.map(tag => `<li class="px-2 py-1 bg-slate-800 text-slate-300 text-xs font-semibold rounded border border-slate-700">#${tag}</li>`).join('')}
                         </ul>
                     </a>

--- a/internal/templates/index.html
+++ b/internal/templates/index.html
@@ -2,7 +2,7 @@
 <div class="flex flex-col gap-16">
     <section class="flex flex-col gap-6">
         <div class="flex flex-col gap-2">
-            <pre class="text-violet-500 text-xs md:text-sm lg:text-base leading-tight font-mono">
+            <pre class="text-violet-500 text-[clamp(8px,2.7vw,16px)] leading-tight font-mono">
 █   █ ███  ███  █████  ███  ████  ███  ███  
 █   █  █  █       █   █   █ █   █  █  █   █ 
 █   █  █  █       █   █   █ ████   █  █████ 
@@ -22,7 +22,7 @@
             {{ range .Config.Socials }}
             <li class="p-2 rounded-md bg-slate-900 border border-slate-800 hover:border-violet-500/30 transition-colors">
                 <a href="{{ .Href }}" target="_blank" rel="noopener noreferrer" class="" aria-label="{{ .Name }}">
-                    <img src="{{ $.PathPrefix }}socials/{{ .Icon }}" alt="{{ .Name }}" class="w-8 h-8 brightness-0 invert opacity-90 hover:opacity-100 transition-opacity">
+                    <img src="{{ $.PathPrefix }}socials/{{ .Icon }}" alt="{{ .Name }}" class="w-5 h-5 brightness-0 invert opacity-90 hover:opacity-100 transition-opacity">
                 </a>
             </li>
             {{ end }}

--- a/internal/templates/work.html
+++ b/internal/templates/work.html
@@ -39,22 +39,24 @@
                     <ul class="flex flex-col gap-3 list-none pl-4 border-l border-violet-500/40">
                         {{ range $itemIndex, $item := $contrib.Items }}
                         <li class="{{ if ge $itemIndex 3 }}hidden additional-pr-{{ $cIndex }} transition-all duration-300{{ end }}">
-                            <a href="{{ $contrib.Link }}/{{ if eq $item.Type "PR" }}pull{{ else }}issues{{ end }}/{{ $item.Number }}" target="_blank" rel="noopener noreferrer" class="group flex items-start gap-2 text-sm">
-                                {{ if eq $item.Type "PR" }}
-                                <span class="{{ if eq $item.Status "merged" }}text-purple-400{{ else }}text-emerald-400{{ end }} shrink-0" title="{{ $item.Status }} Pull Request">
-                                    <svg class="w-4 h-4 shrink-0 mt-0.5" viewBox="0 0 16 16" version="1.1" fill="currentColor" aria-hidden="true">
-                                        <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.67 1.88a.75.75 0 0 1 1.08-.08l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 1 1-1.06-1.06l.97-.97H5.75a.75.75 0 0 1 0-1.5h2.44l-.97-.97a.75.75 0 0 1-.08-1.08ZM13 5.372a2.25 2.25 0 1 1 1.5 0v5.256a2.25 2.25 0 1 1-1.5 0V5.372Zm-1.5-2.122a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm10 0a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"></path>
-                                    </svg>
-                                </span>
-                                {{ else }}
-                                <span class="{{ if eq $item.Status "closed" }}text-purple-400{{ else }}text-emerald-400{{ end }} shrink-0" title="{{ $item.Status }} Issue">
-                                    <svg class="w-4 h-4 shrink-0 mt-0.5" viewBox="0 0 16 16" version="1.1" fill="currentColor" aria-hidden="true">
-                                        <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path>
-                                        <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
-                                    </svg>
-                                </span>
-                                {{ end }}
-                                <span class="text-slate-500 font-mono shrink-0 group-hover:text-violet-400 transition-colors">#{{ $item.Number }}</span>
+                            <a href="{{ $contrib.Link }}/{{ if eq $item.Type "PR" }}pull{{ else }}issues{{ end }}/{{ $item.Number }}" target="_blank" rel="noopener noreferrer" class="group flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-2 text-sm">
+                                <div class="flex items-center gap-1.5 shrink-0">
+                                    {{ if eq $item.Type "PR" }}
+                                    <span class="{{ if eq $item.Status "merged" }}text-purple-400{{ else }}text-emerald-400{{ end }} shrink-0" title="{{ $item.Status }} Pull Request">
+                                        <svg class="w-4 h-4 shrink-0 mt-0.5" viewBox="0 0 16 16" version="1.1" fill="currentColor" aria-hidden="true">
+                                            <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.67 1.88a.75.75 0 0 1 1.08-.08l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 1 1-1.06-1.06l.97-.97H5.75a.75.75 0 0 1 0-1.5h2.44l-.97-.97a.75.75 0 0 1-.08-1.08ZM13 5.372a2.25 2.25 0 1 1 1.5 0v5.256a2.25 2.25 0 1 1-1.5 0V5.372Zm-1.5-2.122a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm10 0a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"></path>
+                                        </svg>
+                                    </span>
+                                    {{ else }}
+                                    <span class="{{ if eq $item.Status "closed" }}text-purple-400{{ else }}text-emerald-400{{ end }} shrink-0" title="{{ $item.Status }} Issue">
+                                        <svg class="w-4 h-4 shrink-0 mt-0.5" viewBox="0 0 16 16" version="1.1" fill="currentColor" aria-hidden="true">
+                                            <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path>
+                                            <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
+                                        </svg>
+                                    </span>
+                                    {{ end }}
+                                    <span class="text-slate-500 font-mono group-hover:text-violet-400 transition-colors">#{{ $item.Number }}</span>
+                                </div>
                                 <span class="text-slate-300 group-hover:text-violet-400 transition-colors leading-snug">{{ $item.Title }}</span>
                             </a>
                         </li>


### PR DESCRIPTION
### Summary
Refactor and polish the website templates to improve mobile responsiveness and visual spacing. This includes aligning navigation items to the left on small screens, ensuring blog tags wrap cleanly, stacking contribution metadata vertically on mobile, and introducing dynamic viewport scaling for the ASCII header on the landing page.

### List of Changes
- Update work.html to stack PR/issue numbers and titles vertically on mobile viewports.
- Spaced out and enabled wrapping for tags in blog.html.
- Left-aligned title and navigation links in base.html header on mobile viewports.
- Resized landing page social icons to w-5 h-5 and implemented clamp() viewport-relative scaling on the ASCII art header in index.html to prevent line wrapping.

### Verification
- [x] Run `make dev-run` to start the local dev container environment, build the site, and manually verify the mobile responsiveness.

