### PR TITLE
chore(ci): standardize github-actions bot identity across workflows

### DIFF
--- a/.github/workflows/publish-blog-post.yml
+++ b/.github/workflows/publish-blog-post.yml
@@ -5,12 +5,16 @@ on:
     - cron: "30 0 * * 2"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      AUTHOR_NAME: '${{ github.actor }}'
-      AUTHOR_EMAIL: '${{ github.actor }}@users.noreply.github.com'
+      AUTHOR_NAME: 'github-actions[bot]'
+      AUTHOR_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/sync-blog-post.yml
+++ b/.github/workflows/sync-blog-post.yml
@@ -4,14 +4,18 @@ on:
     types: [sync-blog-post]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   post:
     runs-on: ubuntu-latest
     env:
       ID: ${{ github.event.client_payload.issue_id }}
       BLOG_TITLE: ${{ github.event.client_payload.issue_title }}
-      AUTHOR_NAME: '${{ github.actor }}'
-      AUTHOR_EMAIL: '${{ github.actor }}@users.noreply.github.com'
+      AUTHOR_NAME: 'github-actions[bot]'
+      AUTHOR_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
       SYNC_BLOG_TOKEN: ${{ secrets.SYNC_BLOG_TOKEN }}
       API_LINK: ${{ vars.API_LINK }}
     steps:

--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Commit and push contribution updates
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH_NAME"
           git add "$PROJECTS_YAML_PATH"
           git commit -m "$UPDATE_MESSAGE"

--- a/.github/workflows/update-fork-cache.yml
+++ b/.github/workflows/update-fork-cache.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Commit and push cache updates
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH_NAME"
           git add "$CACHE_FILE_PATH"
           git commit -m "$UPDATE_MESSAGE"


### PR DESCRIPTION
### Summary
Standardize the GitHub Actions bot identity across all four automated workflows. This ensures automated commits and pull requests are consistently attributed to github-actions[bot] using its official noreply email and dedicated repository permissions.

### List of Changes
- Configure git commit user name and noreply email to github-actions[bot] across all scheduled and event-driven automation workflows.
- Add explicit contents and pull-requests write permissions to publish-blog-post and sync-blog-post workflows.

### Verification
- [x] Verified GitHub Actions bot user ID and official email against GitHub API

